### PR TITLE
Allows users to run spark-bench from repo, fixes an IDE issue

### DIFF
--- a/bin/spark-bench.sh
+++ b/bin/spark-bench.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
+set -eu
 
-WHEREILIVE=$(realpath $0)
-BASEDIR=$(dirname "$WHEREILIVE")
-PARENTDIR=$(dirname "$BASEDIR")
+bin=$(dirname $(realpath $0))
+basedir=$(dirname "$bin")
+if [[ -d "$basedir/lib" ]]
+    then jars="$basedir/lib"
+elif [[ -d "$basedir/target/assembly" ]]
+    then jars="$basedir/target/assembly"
+else
+    echo "Could not find spark-bench JARs." >&2
+    exit 1
+fi
 
-[[ -f "$BASEDIR/spark-bench-env.sh" ]] && source "$BASEDIR/spark-bench-env.sh"
+[[ -f "$bin/spark-bench-env.sh" ]] && source "$bin/spark-bench-env.sh"
 
-SPARK_BENCH_LAUNCH_JAR=$(ls "$PARENTDIR"/lib/spark-bench-launch*.jar)
-MAIN_CLASS="com.ibm.sparktc.sparkbench.sparklaunch.SparkLaunch"
-SPARK_BENCH_JAR=$(ls "$PARENTDIR"/lib/spark-bench-[0-9]*.jar)
+mainclass="com.ibm.sparktc.sparkbench.sparklaunch.SparkLaunch"
+launchjar=$(ls "$jars"/spark-bench-launch-[0-9]*.jar)
+sparkbenchjar=$(ls "$jars"/spark-bench-[0-9]*.jar)
 
-java -cp "$SPARK_BENCH_LAUNCH_JAR" "$MAIN_CLASS" "$@"
+java -cp "$launchjar" "$mainclass" "$@"

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
@@ -55,8 +55,7 @@ object SparkLaunchConf {
     }
 
     val correctedSparkConf = sparkConfMaps ++ master
-    assert(correctedSparkConf.contains("master"))
-    sparkConfMaps.foldLeft(Array[String]()) { case (arr, (k, v)) => arr ++ Array("--" + k, v) }
+    correctedSparkConf.foldLeft(Array[String]()) { case (arr, (k, v)) => arr ++ Array("--" + k, v) }
   }
 
   def getSparkBenchJar(sparkContextConf: Config): String = {

--- a/spark-launch/src/test/resources/etc/noMasterConf.conf
+++ b/spark-launch/src/test/resources/etc/noMasterConf.conf
@@ -1,0 +1,22 @@
+spark-bench = {
+
+  spark-submit-config = [{
+
+    workload-suites = [
+      {
+        descr = "kmeans"
+        parallel = true
+        repeat = 5
+        benchmark-output = "/tmp/spark-bench-scalatest/multi-spark/spark-bench-test/conf-file-output-1.csv"
+
+        workloads = [
+          {
+            name = "kmeans"
+            input = "/tmp/spark-bench-scalatest/multi-spark/spark-bench-test/kmeans-data.parquet"
+            k = 1
+          }
+        ]
+      }
+    ]
+  }]
+}


### PR DESCRIPTION
- Fix for IntelliJ pulling in multiple versions of some jars
- Added test for SPARK_MASTER_HOST with modification of the environment within the test
- Merge branch 'develop' of github.com:ecurtin/spark-bench into develop
- Don't require testing to have SPARK_MASTER_HOST set
- Merge pull request #75 from ecurtin/feature/sparkhome
- Check for JARs in both lib and target/assembly
- Added test for presence of master flag
- Fixed issue with master not being set
- Check for JARs in both lib and target/assembly