### PR TITLE
Add cross-join lists to spark-submit parameters in config file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val utils = project
   .settings(
     commonSettings,
     libraryDependencies ++= sparkDeps,
+    libraryDependencies ++= typesafe,
     libraryDependencies ++= testDeps
   )
 
@@ -80,7 +81,7 @@ lazy val `test-workloads` = project
   .dependsOn(utils % "compile->compile;test->test", cli % "compile->compile")
 
 /*
-    spark-launch relies on having the cli uber jar to launch through spark-submit. So
+    spark-launch relies on having the cli fat jar to launch through spark-submit. So
     in order to test spark-launch, we have to assemble the cli jar and move it into a folder
     that's accessible to the test code for spark-launch.
  */
@@ -98,7 +99,7 @@ lazy val `spark-launch` = project
     moveJar in Test := {
       val log = streams.value.log
       log.info("Assembling spark-bench and custom-workload JARs...")
-      (assembly in Compile in cli).value // This is the magic sauce
+      (assembly in Compile in cli).value
       log.info("Moving assembled JARs to resources folder for test")
       s"mkdir -p ${sparklaunchTestResourcesJarsFile.value}".!
       s"cp ${assemblyFile.value}/${sparkBenchJar.value} ${sparklaunchTestResourcesJarsFile.value}".!
@@ -114,11 +115,8 @@ lazy val `spark-launch` = project
     mainClass in assembly := Some("com.ibm.sparktc.sparkbench.sparklaunch.SparkLaunch"),
     assemblyOutputPath in assembly := new File(s"${assemblyFile.value}/${sparkBenchLaunchJar.value}"),
     libraryDependencies ++= sparkDeps,
-    libraryDependencies ++= Seq(
-      "junit"             % "junit"              % junitVersion       % "test",
-      "org.scalacheck"   %% "scalacheck"         % scalacheckVersion  % "test",
-      "org.scalactic"    %% "scalactic"          % scalatestVersion   % "test",
-      "org.scalatest"    %% "scalatest"          % scalatestVersion   % "test"),
+    libraryDependencies ++= otherCompileDeps,
+    libraryDependencies ++= testDeps,
     libraryDependencies ++= typesafe
   )
   .dependsOn(utils % "compile->compile;test->test", cli % "compile->compile;test->test")

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.util
 
 import com.ibm.sparktc.sparkbench.utils.SparkBenchException
+import com.ibm.sparktc.sparkbench.utils.TypesafeAccessories.configToMapStringAny
 
 import scala.collection.JavaConverters._
 import com.ibm.sparktc.sparkbench.workload.{MultiSuiteRunConfig, Suite}
@@ -42,7 +43,7 @@ object Configurator {
     val parallel: Boolean = Try(config.getBoolean("parallel")).getOrElse(false)
     val repeat: Int = Try(config.getInt("repeat")).getOrElse(1)
     val output: String = config.getString("benchmark-output") // throws exception
-    val workloads: Seq[Map[String, Seq[Any]]]  = getConfigListByName("workloads", config).map(configToMap)
+    val workloads: Seq[Map[String, Seq[Any]]]  = getConfigListByName("workloads", config).map(configToMapStringAny)
 
     Suite.build(
       workloads,
@@ -53,18 +54,6 @@ object Configurator {
     )
   }
 
-  def configToMap(config: Config): Map[String, Seq[Any]] = {
-    val cfgObj = config.root()
-    val unwrapped = cfgObj.unwrapped().asScala.toMap
-    val stuff: Map[String, Seq[Any]] = unwrapped.map(kv => {
-      val newValue: Seq[Any] = kv._2 match {
-        case al: util.ArrayList[Any] => al.asScala
-        case b: Any => Seq(b)
-//        case _ => throw SparkBenchException(s"Key ${kv._1} with value ${kv._2} had an unexpected type: ${kv._2.getClass.toString}")
-      }
-      kv._1 -> newValue
-    })
-    stuff
-  }
+
 
 }

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Suite.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Suite.scala
@@ -1,5 +1,7 @@
 package com.ibm.sparktc.sparkbench.workload
 
+import com.ibm.sparktc.sparkbench.utils.TypesafeAccessories.splitGroupedConfigToIndividualConfigs
+
 case class Suite(
                   description: Option[String],
                   repeat: Int = 1,
@@ -21,29 +23,8 @@ object Suite {
       repeat,
       parallel,
       benchmarkOutput,
-      confsFromArgs.flatMap( splitToIndividualWorkloadConfigs )
+      confsFromArgs.flatMap( splitGroupedConfigToIndividualConfigs )
     )
   }
 
-  //http://stackoverflow.com/questions/14740199/cross-product-in-scala
-  private def crossJoin(list: Seq[Seq[Any]]): Seq[Seq[Any]] =
-    list match {
-      case xs :: Nil => xs map (Seq(_))
-      case x :: xs => for {
-        i <- x
-        j <- crossJoin(xs)
-      } yield Seq(i) ++ j
-    }
-
-  private def splitToIndividualWorkloadConfigs(m: Map[String, Seq[Any]]): Seq[Map[String, Any]] = {
-    val keys: Seq[String] = m.keys.toSeq
-    val valuesSeq: Seq[Seq[Any]] = m.map(_._2).toSeq //for some reason .values wasn't working properly
-
-    // All this could be one-lined, I've multi-lined it and explicit typed it for clarity
-    val joined: Seq[Seq[Any]] = crossJoin(valuesSeq)
-    val zipped: Seq[Seq[(String, Any)]] = joined.map(keys.zip(_))
-    val mapSeq: Seq[Map[String, Any]] = zipped.map(_.map(kv => kv._1.toLowerCase -> kv._2).toMap)
-
-    mapSeq
-  }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ resolvers += Resolver.url("bintray-sbt-plugins", url("https://dl.bintray.com/eed
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/ConfigWrangler.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/ConfigWrangler.scala
@@ -4,10 +4,14 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardOpenOption
 
+import com.ibm.sparktc.sparkbench.utils.TypesafeAccessories._
 import com.typesafe.config._
 import com.typesafe.config.ConfigRenderOptions.concise
 
 import scala.collection.JavaConverters._
+import scala.util.Try
+import com.ibm.sparktc.sparkbench.sparklaunch.{SparkLaunchDefaults => SLD}
+
 
 /*
           _oo____oo_
@@ -22,8 +26,6 @@ import scala.collection.JavaConverters._
 
 object ConfigWrangler {
 
-//  val uuid = java.util.UUID.randomUUID.toString
-
   /**
     * Takes in the path to the config file, splits that file to a bunch of files in a folder in /tmp, returns
     * the paths to those files.
@@ -32,32 +34,82 @@ object ConfigWrangler {
     */
   def apply(path: File): Seq[(SparkLaunchConf, String)] = {
     val config: Config = ConfigFactory.parseFile(path)
-    val sparkBenchConfig = config.getObject("spark-bench").toConfig
-    val sparkContextConfs = getConfigListByName("spark-submit-config", sparkBenchConfig)
+    val sparkBenchConfig = config.getObject(SLD.topLevelConfObject).toConfig
+    val sparkContextConfs  = getListOfSparkSubmits(sparkBenchConfig)
 
-    sparkContextConfs.map { conf =>
-      val tmpFile = Files.createTempFile("spark-bench-", ".conf")
-      // Write this particular spark-context to a separate file on disk.
-      val newConf = sparkBenchConfig
-        .withoutPath("spark-submit-config")
-        .withValue("spark-submit-config", ConfigValueFactory.fromIterable(Iterable(conf.root).asJava))
-      val sbConf = ConfigFactory.empty.withValue("spark-bench", newConf.root)
-      val output = sbConf.root.render(concise.setJson(false))
-      Files.write(tmpFile, output.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
-      // Now create the SparkLaunchConfs
-      (SparkLaunchConf(conf, tmpFile.toString), tmpFile.toString)
+    val processedConfs = sparkContextConfs.flatMap(processConfig)
+    val confsAndPaths: Seq[(Config, String)] = processedConfs.map{ oneConf =>
+      (oneConf, writePartialConfToDisk(sparkBenchConfig, oneConf))
     }
+
+    val ret = confsAndPaths.map{ tuple => {
+        val conf = tuple._1
+        val tmpFilePath = tuple._2
+        (SparkLaunchConf(conf, tmpFilePath), tmpFilePath)
+      }
+    }
+    ret
   }
 
   /**
-    * Utility method to get a piece of the config by the key name.
-    * @param name
+    * Run the confs through the transform pipeline
     * @param config
     * @return
     */
-  private def getConfigListByName(name: String, config: Config): List[Config] = {
-    val workloadObjs: Iterable[ConfigObject] = config.getObjectList(name).asScala
-    workloadObjs.map(_.toConfig).toList
+  private[sparklaunch] def processConfig(config: Config): Seq[Config] = {
+    val a: SparkSubmitDeconstructedWithSeqs = SparkSubmitDeconstructedWithSeqs(config)
+    if(a.sparkSubmitOptions.isEmpty) Seq(config)
+    else {
+      val b: Seq[SparkSubmitDeconstructed] = a.split()
+      val c: Seq[SparkSubmitPieces] = b.map(_.splitPieces)
+      val d: Seq[Config] = c.map(_.reconstruct)
+      d
+    }
+  }
+
+
+  /**
+    * The one config file needs to be split up into individual files that can be submitted to spark-submit. This
+    * @param rootConf
+    * @param oneSparkSubmitConf
+    * @return
+    */
+  private[sparklaunch] def writePartialConfToDisk(rootConf: Config, oneSparkSubmitConf: Config): String = {
+    val tmpFile = Files.createTempFile("spark-bench-", ".conf")
+    // Write this particular spark-context to a separate file on disk.
+    val sbConf = stripSparkSubmitConfPaths(rootConf, oneSparkSubmitConf)
+    val output = sbConf.root.render(concise.setJson(false))
+    Files.write(tmpFile, output.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+    tmpFile.toString
+  }
+
+  /**
+    * Strip all config paths that are not essential for passing on to the next stage of spark-bench.
+    * @param rootConf
+    * @param oneSparkSubmitConf
+    * @return
+    */
+  private[sparklaunch] def stripSparkSubmitConfPaths(rootConf: Config, oneSparkSubmitConf: Config): Config = {
+    val stripped = oneSparkSubmitConf.withOnlyPath(SLD.suites)
+    val suitesParallel: Boolean = Try(oneSparkSubmitConf.getBoolean(SLD.suitesParallel))
+      .toOption
+      .getOrElse(SLD.suitesParallelDefaultValue)
+    val specifyParallelism = stripped.withValue(SLD.suitesParallel, ConfigValueFactory.fromAnyRef(suitesParallel))
+    val wrapWithSparkSubmit = ConfigFactory.empty.withValue(
+      SLD.sparkSubmitObject,
+      ConfigValueFactory.fromIterable(Iterable(specifyParallelism.root).asJava)
+    )
+    val sbConf = ConfigFactory.empty.withValue(SLD.topLevelConfObject, wrapWithSparkSubmit.root)
+    sbConf
+  }
+
+  /**
+    * Utility method to simplify extracting the spark-submit configs
+    * @param rootConfig
+    * @return
+    */
+  private[sparklaunch] def getListOfSparkSubmits(rootConfig: Config): Seq[Config] = {
+    getConfigListByName(s"${SLD.sparkSubmitObject}", rootConfig)
   }
 
 }

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchDefaults.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchDefaults.scala
@@ -1,0 +1,13 @@
+package com.ibm.sparktc.sparkbench.sparklaunch
+
+object SparkLaunchDefaults {
+  val topLevelConfObject = "spark-bench"
+  val sparkSubmitObject = "spark-submit-config"
+  val sparkSubmitParallel = "spark-submit-parallel"
+  val sparkArgs = "spark-args"
+  val sparkConf = "conf"
+  val suites = "workload-suites"
+  val suitesParallel = "suites-parallel"
+
+  val suitesParallelDefaultValue = false
+}

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkSubmitDeconstructed.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkSubmitDeconstructed.scala
@@ -1,0 +1,125 @@
+package com.ibm.sparktc.sparkbench.sparklaunch
+
+import java.util
+
+import com.typesafe.config.{Config, ConfigValueFactory}
+
+import scala.collection.JavaConverters._
+import com.ibm.sparktc.sparkbench.sparklaunch.{SparkLaunchDefaults => SLD}
+import com.ibm.sparktc.sparkbench.utils.TypesafeAccessories.{configToMapStringAny, splitGroupedConfigToIndividualConfigs}
+import com.ibm.sparktc.sparkbench.utils.GeneralFunctions.optionallyGet
+
+import scala.util.Try
+
+
+
+case class SparkSubmitDeconstructedWithSeqs (
+                                              sparkSubmitOptions: Map[String, Seq[Any]],
+                                              suitesConfig: Config
+                                            ) {
+
+  def split(): Seq[SparkSubmitDeconstructed] = {
+    val splitMaps: Seq[Map[String, Any]] = splitGroupedConfigToIndividualConfigs(sparkSubmitOptions)
+    val asJava: Seq[util.Map[String, Any]] = splitMaps.map(_.asJava)
+
+    asJava.map(SparkSubmitDeconstructed(_, suitesConfig))
+  }
+}
+
+object SparkSubmitDeconstructedWithSeqs {
+
+  def apply(oneSparkSubmitConfig: Config): SparkSubmitDeconstructedWithSeqs = {
+    val suites = oneSparkSubmitConfig.withOnlyPath(SLD.suites)
+    val workingConf = oneSparkSubmitConfig.withoutPath(SLD.suites)
+    val map: Map[String, Seq[Any]] = configToMapStringAny(workingConf)
+
+    val newMap = extractSparkArgsToHigherLevel(map, workingConf)
+
+    SparkSubmitDeconstructedWithSeqs(
+      newMap,
+      suites
+    )
+  }
+
+  private def extractSparkArgsToHigherLevel(map: Map[String, Seq[Any]], workingConf: Config): Map[String, Seq[Any]] = {
+    if(map.contains("spark-args")) {
+      val mapStripped = map - "spark-args"
+      val justSparkArgs = workingConf.withOnlyPath("spark-args").getObject("spark-args").toConfig
+      val sparkArgsMap = configToMapStringAny(justSparkArgs)
+
+      val newMap = mapStripped ++ sparkArgsMap
+      newMap
+    }
+    else map
+  }
+}
+
+case class SparkSubmitDeconstructed (
+                                      sparkSubmitOptions: util.Map[String, Any],
+                                      suitesConfig: Config
+                                    ) {
+  def splitPieces: SparkSubmitPieces = {
+
+    def optionMapToJava[K, V](m: Option[Map[K, V]]) = m match {
+      case Some(map) => Some(map.asJava)
+      case _ => None
+    }
+
+    def optionallyGetFromJavaMap[A](m: util.Map[String, Any], key: String): Option[A] = {
+      if (m.containsKey(key))
+        Some(m.get(key).asInstanceOf[A])
+      else None
+    }
+
+    val suitesParallel = optionallyGetFromJavaMap[Boolean](sparkSubmitOptions,SLD.suitesParallel)
+
+    val conf: Option[util.Map[String, Any]] = optionallyGetFromJavaMap[util.Map[String, Any]](sparkSubmitOptions, SLD.sparkConf)
+
+    val sparkArgs: Option[util.Map[String, Any]] = {
+
+      val asScala = sparkSubmitOptions.asScala
+
+
+      val filtered = asScala.filterKeys {
+        case SLD.sparkConf => false
+        case SLD.suitesParallel => false
+        case _ => true
+      }
+      if (filtered.isEmpty) None
+      else Some(filtered.asJava)
+    }
+
+    SparkSubmitPieces(
+      suitesParallel,
+      conf,
+      sparkArgs,
+      suitesConfig
+    )
+  }
+}
+
+case class SparkSubmitPieces (
+                               suitesParallel: Option[Boolean],
+                               conf: Option[util.Map[String, Any]],
+                               sparkArgs: Option[util.Map[String, Any]],
+                               suitesConfig: Config
+                             ) {
+  def reconstruct: Config = {
+
+//    val confToJava = conf match {case Some(m) => Some(m.asJava); case None => None}
+
+    def ifItsThere[A](key: String, option: Option[A]): Option[(String, A)] =
+      Try(key -> option.get).toOption
+
+    val mostOfIt = Seq(
+      ifItsThere(SLD.suitesParallel, suitesParallel),
+      ifItsThere(SLD.sparkConf, conf),
+      ifItsThere(SLD.sparkArgs, sparkArgs)
+    ).flatten.toMap.asJava
+
+    val sparkSubmitConf = ConfigValueFactory.fromMap(mostOfIt)
+
+    val ret = sparkSubmitConf.withFallback(suitesConfig)
+    ret.toConfig
+  }
+}

--- a/spark-launch/src/test/resources/etc/configWrangler1.conf
+++ b/spark-launch/src/test/resources/etc/configWrangler1.conf
@@ -1,0 +1,66 @@
+spark-bench = {
+
+  spark-submit-parallel = true
+
+  spark-submit-config = [{
+    spark-args = {
+      master = ["local[2]", "yarn"]
+    }
+    conf = [
+    {
+      "spark.dynamicAllocation.enabled" = "false"
+      "spark.shuffle.service.enabled" = "false"
+    },
+    {
+      "spark.dynamicAllocation.enabled" = "true"
+      "spark.shuffle.service.enabled" = "true"
+    }]
+
+    workload-suites = [
+    {
+      descr = "KMeans in parallel with k = 1, 2"
+      parallel = true
+      repeat = 5
+      benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-1.csv"
+
+      workloads = [
+      {
+        name = ["kmeans"]
+        input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
+        k = [1]
+      }]
+    }]
+  },
+  {
+    spark-args = {
+      master = "local[4]"
+    }
+    workload-suites = [
+    {
+      descr = "KMeans in parallel with k = 1, 2"
+      parallel = true
+      repeat = 5
+      benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-1.csv"
+
+      workloads = [
+      {
+        name = ["kmeans"]
+        input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
+        k = [2]
+      }]
+    },
+    {
+      descr = "KMeans serially with k = 3, 4"
+      parallel = false
+      repeat = 3
+      benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-2.parquet"
+
+      workloads = [
+      {
+        name = [kmeans]
+        input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
+        k = [3, 4]
+      }]
+    }]
+  }]
+}

--- a/spark-launch/src/test/resources/etc/configWrangler2.conf
+++ b/spark-launch/src/test/resources/etc/configWrangler2.conf
@@ -1,0 +1,24 @@
+spark-bench = {
+
+  spark-submit-parallel = true
+
+  spark-submit-config = [{
+    spark-args = {
+      master = "local[2]"
+    }
+    workload-suites = [
+    {
+      descr = "KMeans in parallel with k = 1, 2"
+      parallel = true
+      repeat = 5
+      benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-1.csv"
+
+      workloads = [
+      {
+        name = ["kmeans"]
+        input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
+        k = [1]
+      }]
+    }]
+  }]
+}

--- a/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/ConfigWranglerTest.scala
+++ b/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/ConfigWranglerTest.scala
@@ -1,0 +1,50 @@
+package com.ibm.sparktc.sparkbench.sparklaunch
+
+import java.io.File
+
+import com.typesafe.config.{ConfigFactory, Config}
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import com.ibm.sparktc.sparkbench.sparklaunch.{SparkLaunchDefaults => SLD}
+
+
+class ConfigWranglerTest extends FlatSpec with Matchers with BeforeAndAfterEach {
+
+  def relativeResource(str: String): File = {
+    val resource = getClass.getResource(str)
+    new File(resource.getPath)
+  }
+
+  val bigConf = relativeResource("/etc/configWrangler1.conf")
+  val moreMinimalConf = relativeResource("/etc/configWrangler2.conf")
+  val toConf: (File) => Config = ConfigFactory.parseFile
+
+  override def beforeEach() {
+
+  }
+
+  override def afterEach() {
+
+  }
+
+  behavior of "ConfigWranglerTest"
+
+  it should "getListOfSparkSubmits" in {
+    val seq: Seq[Config] = ConfigWrangler.getListOfSparkSubmits(toConf(bigConf).getObject(SLD.topLevelConfObject).toConfig)
+    seq.size shouldBe 2
+
+    val seq2: Seq[Config] = ConfigWrangler.getListOfSparkSubmits(toConf(moreMinimalConf).getObject(SLD.topLevelConfObject).toConfig)
+    seq2.size shouldBe 1
+  }
+
+  it should "Process configs into case classes and back" in {
+    val seq1: Seq[Config] = ConfigWrangler.getListOfSparkSubmits(toConf(bigConf).getObject(SLD.topLevelConfObject).toConfig)
+    val seq2: Seq[Config] = ConfigWrangler.getListOfSparkSubmits(toConf(moreMinimalConf).getObject(SLD.topLevelConfObject).toConfig)
+
+    val res1 = seq1.flatMap(ConfigWrangler.processConfig)
+    val res2 = seq2.flatMap(ConfigWrangler.processConfig)
+
+    //TODO ugh, this exposed a bug. Well, I guess that's what tests are supposed to do...
+    res1.size shouldBe 5 // 4 resulting from crossjoin plus 1 more from other spark-submit-config
+    res2.size shouldBe 1
+  }
+}

--- a/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/GeneralFunctions.scala
+++ b/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/GeneralFunctions.scala
@@ -85,6 +85,11 @@ object GeneralFunctions {
 
   def getOrThrow(m: Map[String, Any], key: String): Any = getOrThrow(m.get(key))
 
+  def optionallyGet[A](m: Map[String, Any], key: String): Option[A] = m.get(key) match {
+    case None => None
+    case Some(any) => Some(any.asInstanceOf[A])
+  }
+
   def stringifyStackTrace(e: Throwable): String = {
     import java.io.PrintWriter
     val sw = new StringWriter()

--- a/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/TypesafeAccessories.scala
+++ b/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/TypesafeAccessories.scala
@@ -1,0 +1,118 @@
+package com.ibm.sparktc.sparkbench.utils
+
+import java.util
+
+import scala.collection.JavaConverters._
+import com.typesafe.config.{Config, ConfigObject}
+
+object TypesafeAccessories {
+
+  /**
+    * Utility method to get a piece of the config by the key name.
+    * @param name
+    * @param config
+    * @return
+    */
+  def getConfigListByName(name: String, config: Config): List[Config] = {
+    val workloadObjs: Iterable[ConfigObject] = config.getObjectList(name).asScala
+    workloadObjs.map(_.toConfig).toList
+  }
+
+  /**
+    * Unwraps a Typesafe Config object into a Map[String, Seq[Any]].
+    * Parameters that are not already in a list format will be wrapped in a Seq().
+    *
+    * Example:
+    *
+    * {
+    *   a = "blah"
+    *   b = [1, 2]
+    *   c = ["cool", "stuff"]
+    * }
+    *
+    * is unwrapped and transformed to:
+    *
+    * Map(
+    *   "a" -> Seq("blah"),
+    *   "b" -> Seq(1, 2),
+    *   "c" -> Seq("cool", "stuff")
+    * )
+    *
+    * @param config
+    * @return
+    */
+  def configToMapStringAny(config: Config): Map[String, Seq[Any]] = {
+    val cfgObj = config.root()
+    val unwrapped = cfgObj.unwrapped().asScala.toMap
+    val stuff: Map[String, Seq[Any]] = unwrapped.map(kv => {
+      val newValue: Seq[Any] = kv._2 match {
+        case al: util.ArrayList[Any] => al.asScala
+        case b: Any => Seq(b)
+        //        case _ => throw SparkBenchException(s"Key ${kv._1} with value ${kv._2} had an unexpected type: ${kv._2.getClass.toString}")
+      }
+      kv._1 -> newValue
+    })
+    stuff
+  }
+
+  /**
+    * http://stackoverflow.com/questions/14740199/cross-product-in-scala
+    *
+    * Returns a cross product of the the sequences.
+    *
+    * Example:
+    *
+    * Seq(
+    *   Seq(1, 2),
+    *   Seq("aa", "bb"),
+    *   Seq(4.4)
+    * )
+    *
+    * is crossjoined and the resulting output is:
+    *
+    * Seq(
+    *   Seq(1, "aa", 4.4),
+    *   Seq(1, "bb", 4.4),
+    *   Seq(2, "aa", 4.4),
+    *   Seq(2, "bb", 4.4)
+    * )
+    *
+    * @param list
+    * @return
+    */
+  private def crossJoin(list: Seq[Seq[Any]]): Seq[Seq[Any]] =
+    list match {
+      case xs :: Nil => xs map (Seq(_))
+      case x :: xs => for {
+        i <- x
+        j <- crossJoin(xs)
+      } yield Seq(i) ++ j
+    }
+
+
+  /**
+    * Splits a Map of String to Sequences in a map of string to individual Any items.
+    * @param m
+    * @return
+    */
+  def splitGroupedConfigToIndividualConfigs(m: Map[String, Seq[Any]]): Seq[Map[String, Any]] = {
+    val keys: Seq[String] = m.keys.toSeq
+    val valuesSeq: Seq[Seq[Any]] = m.map(_._2).toSeq //for some reason .values wasn't working properly
+
+    // All this could be one-lined, I've multi-lined it and explicit typed it for clarity
+    val joined: Seq[Seq[Any]] = crossJoin(valuesSeq)
+    val zipped: Seq[Seq[(String, Any)]] = joined.map(keys.zip(_))
+    val mapSeq: Seq[Map[String, Any]] = zipped.map(_.map(kv => kv._1.toLowerCase -> kv._2).toMap)
+
+    mapSeq
+  }
+
+  /**
+    * Takes in a Typesafe config object and splits it into a cross-joined Sequence of Map[String, Any]]
+    * @param config
+    * @return
+    */
+  def configToMapSeq(config: Config): Seq[Map[String, Any]] =
+    splitGroupedConfigToIndividualConfigs( configToMapStringAny( config ) )
+
+}


### PR DESCRIPTION
Cross-join parameter lists are already implemented for workload-suites and workloads. This adds that same functionality to spark-submits. 

Now if users have, for instance, master = ["yarn", "local[2]"] and executor-mem = ["2G", "12G"] then those parameters will create a cross-product of run configurations: yarn + 2G, yarn + 12G, local + 2G, local + 12G.