### PR TITLE
Specifying Precise to prevent build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 branches:
   except:
   - "/^v[0-9]/"


### PR DESCRIPTION
This PR fixes the failing TravisCI builds by specifying that the builds must use Precise (Ubuntu 12) rather than Trusty (Ubuntu 14).

Eventually all TravisCI builds will be on Trusty (Ubuntu 14) rather than Precise (Ubuntu 12) so this fix will not hold forever, but further investigation as to the cause behind the failures will require TravisCI support. I am opening a support issue with them today.

See https://github.com/SparkTC/spark-bench/issues/56 for more discussion on the issue.