### PR TITLE
Sleep workload can use distribution sampling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,8 @@ lazy val cli = project
     libraryDependencies ++= sparkDeps,
     libraryDependencies ++= otherCompileDeps,
     libraryDependencies ++= testDeps,
-    libraryDependencies ++= typesafe
+    libraryDependencies ++= typesafe,
+    libraryDependencies ++= breezeDeps
   )
   .dependsOn(utils % "compile->compile;test->test")
   .aggregate(utils)

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/PartitionAndSleepWorkload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/PartitionAndSleepWorkload.scala
@@ -15,7 +15,7 @@ object PartitionAndSleepWorkload extends WorkloadDefaults {
     input = None,
     output = None,
     partitions = getOrDefault[Int](m, "partitions", partitions),
-    sleepMS = getOrDefault[Long](m, "sleepms", sleepms, any2Int2Long))
+    sleepMS = getOrDefault[Long](m, "sleepms", sleepms, any2Long))
 }
 
 case class PartitionAndSleepWorkload(input: Option[String] = None,

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/Sleep.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/Sleep.scala
@@ -3,30 +3,143 @@ package com.ibm.sparktc.sparkbench.workload.exercise
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import breeze.stats.distributions.{Poisson, Rand}
+import com.ibm.sparktc.sparkbench.utils.SparkBenchException
 
 case class SleepResult(
-                      name: String,
-                      timestamp: Long,
-                      total_runtime: Long
+                        name: String,
+                        timestamp: Long,
+                        total_runtime: Long
                       )
 
 object Sleep extends WorkloadDefaults {
+
+  def optionAnyToOptionLong(a: Option[Any]): Option[Long] = a match {
+    case None => None
+    case Some(any) => Some(any2Long(any))
+  }
+
+
   val name = "sleep"
-  def apply(m: Map[String, Any]) =
-    new Sleep(input = m.get("input").map(_.asInstanceOf[String]),
-      output = None,
-      sleepMS = (m.get("sleepms"), m.get("maxsleepms")) match {
-        case (Some(l), _) => any2Int2Long(l)
-        case (None, Some(l)) => randomLong(max = any2Int2Long(l))
-        case (_, _) => randomLong(max = 3600000L) //one hour
-      }
+  def apply(m: Map[String, Any]): Sleep = {
+
+    val sleepMS: Option[Long] = m.get("sleepms") match {
+      case None => None
+      case Some(any) => Some(any2Long(any))
+    }
+    val distribution: Option[String] = m.get("distribution").asInstanceOf[Option[String]]
+    val distributionMean: Option[Double] = m.get("mean").asInstanceOf[Option[Double]]
+    val distributionStd: Option[Double] = m.get("std").asInstanceOf[Option[Double]]
+    val distributionMin: Option[Long] = optionAnyToOptionLong(m.get("min"))
+    val distributionMax: Option[Long] = optionAnyToOptionLong(m.get("max"))
+
+    def buildWithDist(dist: String) = dist match {
+      case "uniform" => buildWithUniform(distributionMin, distributionMax)
+      case "poisson" => buildWithPoisson(distributionMean)
+      case "gaussian" => buildWithGaussian(distributionMean, distributionStd)
+      case other => throw SparkBenchException(
+        s"""
+           |Distribution $other is not implemented for the Sleep workload.
+           |Please see documentation for available distributions or specify "sleepMS".
+         """.stripMargin)
+    }
+
+    (sleepMS, distribution) match {
+      case (Some(sleep), Some(dist)) => throw  SparkBenchException("Cannot specify both sleepMS and a distribution. " +
+        "Please modify your config file.")
+      case (Some(sleep), None) => buildWithSleepMS(sleep)
+      case (None, None) => throw SparkBenchException("The Sleep workload requires either a time specified by sleepMS " +
+        "or a distribution from which to choose a time. Please modify your config file.")
+      case (None, Some(dist)) => buildWithDist(dist)
+    }
+
+  }
+
+  def buildWithSleepMS(long: Long) = long match {
+    case x if long <= 0 => throw SparkBenchException("The time specified by sleepMS must be greater than or equal to zero. " +
+      "Please modify your config file.")
+    case y if long > 0 =>  new Sleep( sleepMS = long )
+  }
+
+
+  def buildWithPoisson(mean: Option[Double]): Sleep = {
+    def poissonDraw(mean: Double): Long = {
+      val dist = Poisson(mean)
+      dist.draw().toLong
+    }
+
+    val sleepTime = mean match {
+      case None => throw SparkBenchException("Using the Poisson distribution for the Sleep workload " +
+        "requires a value for \"distributionMean\". Please modify your config file.")
+      case Some(m) => poissonDraw(m)
+    }
+
+    Sleep(
+      sleepMS = sleepTime,
+      distribution = Some("poisson"),
+      distributionMean = mean
     )
+  }
+
+
+  def buildWithUniform(min: Option[Long], max: Option[Long]): Sleep = {
+    def uniformRandomDraw(max: Long): Long = {
+      val dist = Rand.randLong(max)
+      dist.draw()
+    }
+
+    val minimum: Long = getOrDefaultOpt[Long](min, 0L, any2Long)
+    val adjustedMax: Long = max match {
+      case None => throw SparkBenchException("Using the uniform distribution for the Sleep workload " +
+        "requires a value for \"distributionMax\". Please modify your config file.")
+      case Some(m) => {
+        val x = any2Long(m)
+        val y = x - minimum
+        y
+      }
+    }
+
+    val sleepTime = uniformRandomDraw(adjustedMax) + minimum
+
+    Sleep(
+      sleepMS = sleepTime,
+      distribution = Some("uniform"),
+      distributionMin = Some(minimum),
+      distributionMax = max
+    )
+  }
+
+  def buildWithGaussian(mean: Option[Double], std: Option[Double]): Sleep = {
+    def gaussianDraw(mean: Double, std: Double): Long = {
+      val dist = Rand.gaussian(mean, std)
+      dist.draw().toLong
+    }
+    val sleepTime = (mean, std) match {
+      case (Some(m),Some(s)) => gaussianDraw(m, s)
+      case _ => throw SparkBenchException("Using the gaussian distribution for the Sleep workload " +
+        "requires a value for \"distributionMean\" and \"distributionMax\". Please modify your config file.")
+    }
+    Sleep(
+      sleepMS = sleepTime,
+      distribution = Some("gaussian"),
+      distributionMean = mean,
+      distributionStd = std
+    )
+  }
+
+
+
 }
 
 case class Sleep(
                 input: Option[String] = None,
                 output: Option[String] = None,
-                sleepMS: Long
+                sleepMS: Long,
+                distribution: Option[String] = None,
+                distributionMean: Option[Double] = None,
+                distributionStd: Option[Double] = None,
+                distributionMin: Option[Long] = None,
+                distributionMax: Option[Long] = None
               ) extends Workload {
 
   override def doWorkload(df: Option[DataFrame] = None, spark: SparkSession): DataFrame = {

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/ml/KMeansWorkload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/ml/KMeansWorkload.scala
@@ -42,7 +42,7 @@ object KMeansWorkload extends WorkloadDefaults {
     input = Some(getOrThrow(m, "input").asInstanceOf[String]),
     output = getOrDefault[Option[String]](m, "workloadresultsoutputdir", None),
     k = getOrDefault[Int](m, "k", numOfClusters),
-    seed = getOrDefault(m, "seed", seed, any2Int2Long),
+    seed = getOrDefault(m, "seed", seed, any2Long),
     maxIterations = getOrDefault[Int](m, "maxiterations", maxIteration))
 
 }

--- a/cli/src/test/resources/etc/notebook-sim.conf
+++ b/cli/src/test/resources/etc/notebook-sim.conf
@@ -21,7 +21,7 @@ spark-bench = {
           },
           {
             name = "sleep"
-            sleepms = 6000
+            sleepMS = 6000
           },
           {
             name = "kmeans"
@@ -30,7 +30,7 @@ spark-bench = {
           },
           {
             name = "sleep"
-            maxsleepms = 60000
+            sleepMS = 60000
           }
         ]
       },
@@ -49,7 +49,7 @@ spark-bench = {
           },
           {
             name = "sleep"
-            sleepms = 10000
+            sleepMS = 10000
           },
           {
             name = "sql"
@@ -58,7 +58,7 @@ spark-bench = {
           },
           {
             name = "sleep"
-            sleepms = 10000
+            sleepMS = 10000
           },
           {
             name = "sql"
@@ -67,7 +67,7 @@ spark-bench = {
           },
           {
             name = "sleep"
-            sleepms = 10000
+            sleepMS = 10000
           }
         ]
       }

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/exercise/SleepTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/exercise/SleepTest.scala
@@ -1,0 +1,210 @@
+package com.ibm.sparktc.sparkbench.workload.exercise
+
+import com.ibm.sparktc.sparkbench.testfixtures.SparkSessionProvider
+import com.ibm.sparktc.sparkbench.utils.SparkBenchException
+import org.scalatest.{FlatSpec, Matchers}
+
+class SleepTest extends FlatSpec with Matchers {
+
+  "The Sleep workload creation object" should "generate a case class properly with just sleepMS" in {
+
+    val m: Map[String, Any] = Map(
+      "name" -> "sleep",
+      "sleepms" -> 6500
+    )
+
+    val thisResult: Sleep = Sleep(m)
+
+    val that: Sleep = new Sleep(
+      sleepMS = 6500L
+    )
+
+    thisResult.distribution shouldBe that.distribution
+    thisResult.distributionMax shouldBe that.distributionMax
+    thisResult.distributionMin shouldBe that.distributionMin
+    thisResult.sleepMS shouldBe that.sleepMS
+  }
+
+  it should "throw an error when sleepMS and distribution are both specified" in {
+    val m: Map[String, Any] = Map(
+      "name" -> "sleep",
+      "sleepms" -> 6500,
+      "distribution" -> "poisson"
+    )
+
+    a [SparkBenchException] should be thrownBy Sleep(m)
+  }
+
+  it should "throw an error when neither sleepMS nor distribution are specified" in {
+    val m: Map[String, Any] = Map(
+      "name" -> "sleep",
+      "mean" -> 11000
+    )
+
+    a [SparkBenchException] should be thrownBy Sleep(m)
+  }
+
+  it should "throw an error when sleepMS is negative" in {
+    val m: Map[String, Any] = Map(
+      "name" -> "sleep",
+      "sleepms" -> -3
+    )
+
+    a [SparkBenchException] should be thrownBy Sleep(m)
+  }
+
+  it should "generate properly when uniform distribution is specified" in {
+    val m = Map(
+      "name" -> "sleep",
+      "distribution" -> "uniform",
+      "max" -> 6500,
+      "min" -> 6498
+    )
+
+    val thisResult: Sleep = Sleep(m)
+
+    val that: Sleep = new Sleep(
+      distribution = Some("uniform"),
+      distributionMax = Some(6500L),
+      distributionMin = Some(6498L),
+      sleepMS = -1 //just to satisfy constructor
+    )
+
+    thisResult.distribution shouldBe that.distribution
+    thisResult.distributionMax shouldBe that.distributionMax
+    thisResult.distributionMin shouldBe that.distributionMin
+    thisResult.sleepMS should be >= that.distributionMin.get
+    thisResult.sleepMS should be <= that.distributionMax.get
+  }
+
+  it should "generate properly when uniform distribution is specified and there is no min parameter present" in {
+    val m = Map(
+      "name" -> "sleep",
+      "distribution" -> "uniform",
+      "max" -> 6500
+    )
+
+    val thisResult: Sleep = Sleep(m)
+
+    val that: Sleep = new Sleep(
+      distribution = Some("uniform"),
+      distributionMax = Some(6500L),
+      distributionMin = Some(0L),
+      sleepMS = -1 //just to satisfy constructor
+    )
+
+    thisResult.distribution shouldBe that.distribution
+    thisResult.distributionMax shouldBe that.distributionMax
+    thisResult.distributionMin shouldBe that.distributionMin
+    thisResult.sleepMS should be >= 0L
+    thisResult.sleepMS should be <= that.distributionMax.get
+  }
+
+  it should "throw an error when components needed for building with uniform distribution are not present" in {
+    // No required "max" present
+    val m = Map(
+      "name" -> "sleep",
+      "distribution" -> "uniform",
+      "min" -> 6000
+    )
+
+    a [SparkBenchException] should be thrownBy Sleep(m)
+  }
+
+
+
+  it should "generate properly when Poisson distribution is specified" in {
+    val m = Map(
+      "name" -> "sleep",
+      "distribution" -> "poisson",
+      "mean" -> 10000.0
+    )
+
+    val thisResult: Sleep = Sleep(m)
+
+    val that: Sleep = new Sleep(
+      distribution = Some("poisson"),
+      distributionMean = Some(10000.0),
+      sleepMS = -1 //just to satisfy constructor
+    )
+
+    thisResult.distribution shouldBe that.distribution
+    thisResult.distributionMean shouldBe that.distributionMean
+    thisResult.sleepMS should be >= 0L
+  }
+
+  it should "throw an error when components needed for building with Poisson are not present" in {
+    // No required mean present
+    val m = Map(
+      "name" -> "sleep",
+      "distribution" -> "poisson"
+    )
+
+    a [SparkBenchException] should be thrownBy Sleep(m)
+  }
+
+  it should "generate properly when Gaussian distribution is specified" in {
+    val m = Map(
+      "name" -> "sleep",
+      "distribution" -> "gaussian",
+      "mean" -> 10000.0,
+      "std" -> 1000.0
+    )
+
+    val thisResult: Sleep = Sleep(m)
+
+    val that: Sleep = new Sleep(
+      distribution = Some("gaussian"),
+      distributionMean = Some(10000.0),
+      distributionStd = Some(1000.0),
+      sleepMS = -1 //just to satisfy constructor
+    )
+
+    thisResult.distribution shouldBe that.distribution
+    thisResult.distributionMean shouldBe that.distributionMean
+    thisResult.distributionStd shouldBe that.distributionStd
+    thisResult.sleepMS should be >= 0L
+  }
+
+  it should "throw an error when components needed for building with Gaussian are not present" in {
+
+    // Required mean not present
+    val m1 = Map(
+      "name" -> "sleep",
+      "distribution" -> "gaussian",
+      "std" -> 1000.0
+    )
+
+    a [SparkBenchException] should be thrownBy Sleep(m1)
+
+    // Required standard deviation not present
+    val m2 = Map(
+      "name" -> "sleep",
+      "distribution" -> "gaussian",
+      "mean" -> 10000.0
+    )
+
+    a [SparkBenchException] should be thrownBy Sleep(m2)
+  }
+
+  "The Sleep workload" should "sleep for greater than or equal to the number of milliseconds specified" in {
+    val m: Map[String, Any] = Map(
+      "name" -> "sleep",
+      "sleepms" -> 1000
+    )
+
+    val sleepWorkload: Sleep = Sleep(m)
+    val oneRow = sleepWorkload.doWorkload(None, SparkSessionProvider.spark).head
+    val runtime = oneRow.getAs[Long]("total_runtime")
+    // Total runtime is measured in microseconds, so we first divide by 1,000,000
+    val oneMillion = 1000000L
+
+    /*
+      There is overhead associated with the time() function itself,
+      so the total time to run a thread sleep of x milliseconds will be x + some epsilon.
+      Here we are using 50 milliseconds as a generous epsilon.
+    */
+    runtime / oneMillion shouldBe 1000L +- 50L
+  }
+
+}

--- a/docs/workloads-and-parameters.md
+++ b/docs/workloads-and-parameters.md
@@ -92,13 +92,60 @@ or for a random  number of milliseconds less than 3600000L (one hour).
 
 **Parameters**
 
+The Sleep workload can work in two different ways. 
+
+1. Specify a specific number of milliseconds for the thread to sleep
+2. Draw from a distribution. Available distributions are uniform random, gaussian, and Poisson
+
+_To Specify A Specific Number Of Milliseconds_  
+
 | Name        | Required (y/n)| Default  | Description |
 | ----------- |---------------| ---------| ------------|
-| sleepms     | no |  | specific number of milliseconds the thread should sleep |
-| maxsleepms  | no |  | sleep for a random number of milliseconds less than maxsleepms |
+| sleepMS     | no |  | specific number of milliseconds the thread should sleep |
 
-If neither sleepms nor maxsleepms are defined, the Sleep workload will default to sleeping
-for a random number of milliseconds less than 3600000L (one hour).
+_To Draw From A Distribution_
+
+| Name        | Required (y/n)| Default  | Description |
+| ----------- |---------------| ---------| ------------|
+| distribution     | yes | -- | "uniform", "gaussian", or "poisson" |
+| min     | no, optional for uniform | 0 | Minimum value of the uniform distribution |
+| max     | yes for uniform | -- | Maximum number of milliseconds. Uniform distribution will choose a number \[(min or 0), max\] |
+| mean    | yes for gaussian and poisson | -- | Mean of the gaussian or Poisson distribution |
+| std     | yes for gaussian | -- | Standard deviation for the gaussian distribution |
+
+**Examples**
+```hocon
+// Sleep the thread for exactly 60000 milliseconds
+{
+  name = "sleep"
+  sleepMS = 60000
+}
+```
+```hocon
+// Sleep the thread for a number of milliseconds [0, max] chosen from a uniform distribution
+{
+  name = "sleep"
+  distribution = "uniform"
+  max = 60000
+}
+```
+```hocon
+// Sleep the thread for a number of milliseconds chosen from a Poisson distribution with a mean of 30000
+{
+  name = "sleep"
+  distribution = "poisson"
+  mean = 30000
+}
+```
+```hocon
+// Sleep the thread for a number of milliseconds chosen from a gaussian distribution with a mean of 30000 and standard deviation of 1000
+{
+  name = "sleep"
+  distribution = "gaussian"
+  mean = 30000
+  std = 1000
+}
+```
 
 ## Machine Learning and Statistics Workloads
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,15 @@ object Dependencies {
     "org.apache.spark" %% "spark-sql"   % sparkVersion % "provided"
   )
 
+  //According to Breeze documentation, SBT 0.13.3+ requires this crazy thing
+  val breezeDeps = Seq(
+    "com.github.fommil.netlib" % "all" % "1.1.2" pomOnly(),
+
+  "org.scalanlp" % "breeze_2.11" % "0.13.2"
+//    ,
+//    "org.scalanlp" %% "breeze-natives" % "0.13.2"
+  )
+
   val otherCompileDeps = Seq(
 //    "org.jblas" % "jblas" % "1.2.4"
   )
@@ -24,7 +33,7 @@ object Dependencies {
     "org.scalactic"    %% "scalactic"          % scalatestVersion   % "test",
     "org.scalatest"    %% "scalatest"          % scalatestVersion   % "test",
     "org.apache.spark" %% "spark-hive"         % sparkVersion       % "test",
-    "com.holdenkarau"  %% "spark-testing-base" % "2.1.0_0.6.0"      % "test" excludeAll(
+    "com.holdenkarau"  %% "spark-testing-base" % "2.1.1_0.7.2"      % "test" excludeAll(
       ExclusionRule(organization = "org.scalacheck"),
       ExclusionRule(organization = "org.scalactic"),
       ExclusionRule(organization = "org.scalatest"),

--- a/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/GeneralFunctions.scala
+++ b/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/GeneralFunctions.scala
@@ -7,33 +7,9 @@ import scala.util.{Failure, Random, Success, Try}
 
 object GeneralFunctions {
 
-  val any2Int2Long = (a: Any) => Try{
-    val x = a.asInstanceOf[Int]
-    x.toLong
-  } match {
-    case Success(l) => l
-    case Failure(ex) => throw ex
+  val any2Long = (a: Any) => {
+    a.asInstanceOf[Number].longValue()
   }
-
-//  def getOrDefault[A](
-//                       map: Map[String, Any],
-//                       name: String, default: A,
-//                       optFunc: Option[(Any) => A] = None
-//                     ): A ={
-//    val optA: Option[Any] = map.get(name)
-//
-//    val castedValue: Option[A] = optA match {
-//      case Some(b) => Try(b.asInstanceOf[A]).toOption
-//      case None => None
-//    }
-//
-//    (optA, castedValue, optFunc) match {
-//      case (None, _, _) => default
-//      case (Some(a), Some(v), _) => v
-//      case (Some(a), None, Some(f)) => f(a)
-//      case (_, _, _) => default
-//    }
-//  }
 
   def getOrDefault[A](
                        map: Map[String, Any],
@@ -52,6 +28,22 @@ object GeneralFunctions {
     }
   }
 
+  def getOrDefaultOpt[A](
+                       opt: Option[Any],
+                       default: A,
+                       func: (Any) => A = {(any: Any) => any.asInstanceOf[A]}
+                     ): A = {
+
+    val any = opt match {
+      case None => return default
+      case Some(a) => a
+    }
+
+    Try(func(any)) match {
+      case Success(b) => b
+      case Failure(_) => default
+    }
+  }
 
   def time[R](block: => R): (Long, R) = {
     val t0 = System.nanoTime()


### PR DESCRIPTION
This refactors the Sleep workload so that users have a variety of options for using it. Before, the Sleep workload could either accept a number of milliseconds to sleep the thread, or it would generate a number less than a given max.

Now, users still have the option of providing a simple number of milliseconds as before, but they also have the option of drawing from a uniform distribution with min and max, a Poisson distribution with a given mean (especially useful for simulating multiple users on a cluster), or a Gaussian distribution with a mean and standard deviation. This model is extensible to other distributions in the future should users require.

The distribution functionality is built using the Breeze library.