### PR TITLE
Specifying Trusty distribution for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: trusty
 branches:
   except:
   - "/^v[0-9]/"


### PR DESCRIPTION
TravisCI has fixed an issue on their end which was causing spark-bench
tests to fail. We can now safely move to using Trusty as the main
distribution.