### PR TITLE
Add realpath function

### DIFF
--- a/bin/spark-bench.sh
+++ b/bin/spark-bench.sh
@@ -1,6 +1,26 @@
 #!/bin/bash
 set -eu
 
+realpath () {
+(
+  TARGET_FILE="$1"
+
+  cd "$(dirname "$TARGET_FILE")"
+  TARGET_FILE="$(basename "$TARGET_FILE")"
+
+  COUNT=0
+  while [ -L "$TARGET_FILE" -a $COUNT -lt 100 ]
+  do
+      TARGET_FILE="$(readlink "$TARGET_FILE")"
+      cd $(dirname "$TARGET_FILE")
+      TARGET_FILE="$(basename $TARGET_FILE)"
+      COUNT=$(($COUNT + 1))
+  done
+
+  echo "$(pwd -P)/"$TARGET_FILE""
+)
+}
+
 bin=$(dirname $(realpath $0))
 basedir=$(dirname "$bin")
 if [[ -d "$basedir/lib" ]]


### PR DESCRIPTION
The shell script uses realpath and this does not work on my Mac.
I borrowed the `realpath` from https://github.com/apache/spark/blob/master/build/sbt

If we do https://github.com/SparkTC/spark-bench/issues/115, then we should also add the `realpath` function to that script.