### PR TITLE
Stripping README, improving docs site

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,6 +1,7 @@
 <!-- WELCOME to Spark-Bench! Thanks for being a part of the project! -->
-<!-- If you are submitting a bug, filling out the following details helps us resolve your issue much faster. -->
-<!-- If you are proposing a new feature or otherwise contributing an issue, feel free to skip this step :) -->
+
+<!-- If you are submitting a bug, filling out the following details helps us resolve your issue much faster.
+If you are proposing a new feature or otherwise contributing an issue, feel free to skip this step :) -->
 ### Spark-Bench Version
 
 <!-- Example: spark-bench_2.1.1_0.2.2-RELEASE_47 -->
@@ -16,13 +17,13 @@
 
 ### Your Exact Configuration File (with system details anonymized)
 
-<!-- Please copy-paste your exact configuration file. -->
-<!-- Anonymize any system details such as your IP. --> 
-<!-- For example, if you are running in Spark Standalone, -->
-<!-- please change master = "spark://10.89.34.56:7077" to master = "spark://xx.xx.xx.xx:7077 -->
+<!-- Please copy-paste your exact configuration file.
+Anonymize any system details such as your IP. 
+For example, if you are running in Spark Standalone, 
+please change master = "spark://10.89.34.56:7077" to master = "spark://xx.xx.xx.xx:7077 -->
 
-<!-- Please surround your configuration file with three backticks ``` before and after your configuration. -->
-<!-- This forces code formatting for markdown and makes it MUCH easier to read! -->
+<!-- Please surround your configuration file with three backticks ``` before and after your configuration.
+This forces code formatting for markdown and makes it MUCH easier to read! -->
 
 ### Relevant Stack Trace (If Applicable)
 

--- a/docs/_developers-guide/building_spark-bench.md
+++ b/docs/_developers-guide/building_spark-bench.md
@@ -1,0 +1,75 @@
+---
+layout: page
+title: Building Spark-Bench
+permalink: /compilation/
+---
+
+## Preparing Your Environment
+1. Install SBT according to the instructions for your system: <http://www.scala-sbt.org/0.13/docs/Setup.html>
+
+2. Clone this repo.
+```bash
+git clone https://github.com/Spark-TC/spark-bench.git
+cd spark-bench/
+```
+Make sure you are on the master branch.
+```bash
+git checkout master
+```
+
+3. Change your SBT heap space. Building spark-bench takes more heap space than the default provided by SBT. There are several ways to set these options for SBT, 
+this is just one. I recommend adding the following line to your bash_profile:
+```bash
+export SBT_OPTS="-Xmx1536M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=2G -Xss2M"
+```
+
+If you are working directly on the Spark-Bench code, you are of course welcome to use any text editor or IDE you wish, though 
+I would strongly encourage using the community edition of IntelliJ with the Scala, SBT, .gitignore, and Markdown plugins installed. 
+
+## Using Spark-Bench from the Source Code Folder
+
+You can use Spark-Bench from the source code repo without having to use the pre-compiled distribution. 
+To do this, you will need to first follow the same steps as you would for installing from the distribution:
+
+1. Make sure you have a local installation of Spark 2.x available to you.
+2. Modify the example files to point to your spark-home and master OR set the environment variables.
+
+For more info about the first two steps, see [the installation guide](../_users-guide/installation.md).
+
+Finally, you will need to perform one more step to use Spark-Bench from the source code folder. 
+While the distribution folder already contains the precompiled jars,
+you will need to create the necessary jars in the source code repo yourself. 
+Thankfully, this is really easy! Just run
+```bash
+sbt assembly
+```
+which will create the necessary jars in the `target` folder. 
+
+spark-bench.sh looks first for jars in a local `lib/` folder, then in a local `target` folder. Once you have run `sbt assembly`,
+You can use spark-bench.sh as usual and it will reference the jars in the target folder.
+```bash
+./bin/spark-bench.sh docs/_examples/minimal-config-file.md
+```
+
+## SBT Commands for Spark-Bench
+
+### Useful Standard SBT Commands
+- `sbt compile` compiles the code.
+- `sbt refresh` will ensure the dependencies are pulled to your development environment and sync the project with any changes in the build.sbt.
+- `sbt clean` cleans compiled class files and other fodder from project. Also has been slightly modified to call `rmDist` in addition to normal functions.
+- `sbt test` runs all the unit tests in the project.
+
+### Custom SBT Commands For Spark-Bench
+- `sbt assembly` creates the two fat JARs of the project in the `target` folder. `assembly` is an SBT plugin.
+- `sbt dist` creates the distribution folder for release and a tar of that same folder. TravisCI runs SBT dist to create the file that is uploaded to Github Releases. 
+`dist` is a custom SBT action defined in this project's build.sbt.
+- `sbt rmDist` cleans up any distribution files and associated tar files created by `sbt dist`.
+
+## Docs Site
+This documenation site that you're reading now is a Jekyll site generated from files in the `docs/` folder.
+To see the Jekyll site locally:
+
+1. Follow the instructions [from Github](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/)
+regarding installing Ruby, bundler, etc.
+
+2. From the `docs/` folder, run `bundle exec jekyll serve` and navigate in your browser to `127.0.0.1:4000`

--- a/docs/_developers-guide/contributing.md
+++ b/docs/_developers-guide/contributing.md
@@ -1,0 +1,129 @@
+---
+layout: page
+title: Contributing to Spark-Bench
+permalink: /contributing/
+---
+
+Thank you for your interest in contributing to Spark-Bench!
+
+## Fork The Project
+
+In order to contribute code to Spark-Bench, you will need to first fork the project.
+Github provides lots of excellent documentation: <https://help.github.com/articles/fork-a-repo/>
+
+## Getting Your Dev Environment Setup
+Follow the instructions for cloning and compiling Spark-Bench in the [compilation guide](../developers-guide/building_spark-bench.md)
+
+## Finding a Starter Issue
+There are many issues marked in Github as `help wanted`. Usually these are easy to medium difficulty.
+If any interest you, feel free to pick it up directly or get in touch with the main Spark-Bench devs to
+ask questions about it :)
+
+## Setup Your Feature Branch
+From the master branch in your fork, create a new branch with a
+short but descriptive name for what your changes will be. For example,
+if you're doing updates to the documentation site, you may want
+to name your branch `doc-updates`. How you structure branches in your fork is totally
+up to you!
+
+## Making Your Pull Request
+You've made your code changes, you've tested them locally, 
+you're almost ready to contribute your changes back! Woo!!
+
+First, you'll need to touch up your branch and commit messages using git.
+
+A good pull request has just 1 commit with a well-formatted commit message.
+It is up to date with the current master, and can be easily rebased onto the 
+main master branch with no merge commits.
+
+There are a variety of ways to squash all the commits in your branch down to one.
+We'll describe just one way here, but there are many others.
+
+### Syncing Master
+Let's assume that you have a fork under your own username on Github, and that you've
+setup the main SparkTC/spark-bench repo 
+[as a remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/) named `upstream`,
+like so:
+
+```bash
+$ git remote -v
+origin  git@github.com:ecurtin/spark-bench.git (fetch)
+origin  git@github.com:ecurtin/spark-bench.git (push)
+upstream        git@github.com:SparkTC/spark-bench.git (fetch)
+upstream        git@github.com:SparkTC/spark-bench.git (push)
+```
+
+A best practice is to keep your master branch in your repo free of any changes so that
+you can easily sync it with the upstream repo, and to do all of your development work
+in a separate branch.
+
+Let's say you have two branches, `master` which is free of any changes, and `doc-updates`
+which has some new changes to contribute.
+
+First, make sure your local copy of `master` is up to date.
+```bash
+git checkout master
+git pull upstream master
+git push origin master
+```
+This pulls any new changes from SparkTC/spark-bench into your local repo, 
+then pushes them up to your fork which in this case is ecurtin/spark-bench.
+
+### Rebasing Your Changes On Top Of Master
+Now let's go back to the branch with your changes
+```bash
+git checkout doc-updates
+```
+
+If you're inexperienced with squashing and rebasing, it might be good
+to use a copy of your branch in case something goes wrong.
+```bash
+git checkout -b rebasing-is-fun
+```
+
+We're going to rebase the changes in this branch _on top of_ the changes in master
+```bash
+git rebase master
+```
+
+### Squashing Your Commits
+Now that all our changes are on top of the latest updates from master, we want to squash
+all the commits you've made while working on your feature into just one commit.
+Again, there are _many_ ways to do this, this is just one.
+
+Let's say you have three commits that you want to get down to just one.
+```bash
+git rebase -i HEAD~3
+```
+
+This will open up a file in Vim or whatever default editor you have set for git
+with a list of your commits in chronological order.
+
+Beside each commit will be the word `pick`. Using your text editor, keep the first
+commit as `pick` but change the second two to `s` or `squash`.
+Save and close this file and git will run the process. Then it will give you a chance
+to rewrite your commit message.
+
+### Formatting Your Commit Message
+
+Your commit message should have a subject that is 50 characters or less
+followed by a body that is line-wrapped at 72 characters.
+
+For instructions, examples, and more information about formatting 
+a great commit message, see [this blog post](http://blog.ssanj.net/posts/2015-10-22-git-commit-message-format.html)
+
+### Sync Your New Changes
+Now that your changes are on your branch, push them up to your fork on Github.
+```bash
+git push origin
+```
+
+### Create Your PR on Github
+
+Github has lots of [excellent documentation](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) 
+for this if you're unfamiliar with the process.
+
+## Don't Be Shy!
+If you're a first-time open source contributor, we are SO glad that you're here!
+Please feel free to reach out to the main Spark-Bench devs for questions and for help with 
+getting your contribution into Spark-Bench 🙂

--- a/docs/_developers-guide/spark-bench-build.md
+++ b/docs/_developers-guide/spark-bench-build.md
@@ -1,7 +1,0 @@
----
-layout: page
-title: Build Structure of Spark-Bench
----
-
-spark-bench is a multi-project SBT build. The build is mainly defined in [build.sbt](../build.sbt) and dependencies
-are defined in [Dependencies.scala](../project/Dependencies.scala).

--- a/docs/_users-guide/installation.md
+++ b/docs/_users-guide/installation.md
@@ -1,0 +1,89 @@
+---
+layout: page
+title: Installation
+---
+_This guide assumes you have a working installation of Spark 2.x available and that you have access
+to the system where it is installed._
+
+## Installation Summary
+
+1. Grab the latest release from here: <https://github.com/Spark-TC/spark-bench/releases/latest>.
+2. Unpack the tarball using `tar -xvzf`.
+3. `cd` into the newly created folder.
+4. Set your environment variables
+  - Option 1: modify `SPARK_HOME` and `SPARK_MASTER_HOST` in `bin/spark-bench-env.sh` to reflect your environment. 
+  - **Option 2: Recommended!** Modify the config files in the examples and set `spark-home` and `spark-args = { master }` 
+  to reflect your environment. (_See below for more info!_)
+5. Start using spark-bench!
+```bash
+./bin/spark-bench.sh /path/to/your/config/file.conf
+```
+
+### Setting Environment Variables
+There are two ways to set the Spark home and master variables necessary to run the examples. 
+
+#### Option 1: Setting Bash Environment Variables
+Inside the `bin` folder is a file called `spark-bench-env.sh`. In this folder are two environment variables
+that you will be required to set. The first is `SPARK_HOME` which is simply the full path to the top level of your
+Spark installation on your laptop or cluster. The second is SPARK_MASTER_HOST which is the same as what you
+would enter as `--master` in a spark submit script for this environment. This might be `local[2]` on your laptop,
+`yarn` on a Yarn cluster, an IP address and port if you're running in standalone mode, you get the idea!
+
+You can set those environment variables in your bash profile or by uncommenting the lines in `spark-bench-env.sh`
+and filling them out in place.
+
+#### Option 2: RECOMMENDED! Modifying Example Config Files To Include Environment Info
+For example, in the minimal-example.conf, which looks like this:
+```hocon
+spark-bench = {
+  spark-submit-config = [{
+    workload-suites = [
+      {
+        descr = "One run of SparkPi and that's it!"
+        benchmark-output = "console"
+        workloads = [
+          {
+            name = "sparkpi"
+            slices = 10
+          }
+        ]
+      }
+    ]
+  }]
+}
+```
+
+Add the spark-home and master keys.
+```hocon
+spark-bench = {
+  spark-home = "/path/to/your/spark/install/" 
+  spark-submit-config = [{
+    spark-args = {
+      master = "local[*]" // or whatever the correct master is for your environment
+    }
+    workload-suites = [
+      {
+        descr = "One run of SparkPi and that's it!"
+        benchmark-output = "console"
+        workloads = [
+          {
+            name = "sparkpi"
+            slices = 10
+          }
+        ]
+      }
+    ]
+  }]
+}
+```
+
+### Running the Examples
+From the spark-bench distribution file, simply run:
+
+```bash
+./bin/spark-bench.sh ./examples/minimal-example.conf
+```
+
+The example scripts and associated configuration files are a great starting point for learning spark-bench by example.
+You can also read more about spark-bench at our [documentation site](https://sparktc.github.io/spark-bench/)
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,15 @@ layout: page
 title: "Spark-Bench"
 ---
 Spark-Bench is a flexible system for benchmarking and simulating Spark jobs. 
-It can do two main things:
-1. Run workloads in a highly configurable fashion
-2. Generate data
 
-Users configure the way their jobs run by defining `spark-submits`, `workload-suites`, and `workloads` in a nested structure.
+You can use Spark-Bench to do traditional benchmarking, to stress test your cluster, to simulate multiple users 
+hitting a cluster at the same time, and much more!
+
+Users configure the way their jobs run by defining 
+[spark-submit configs]({{ "/users-guide/spark-submit-config" | relative_url }}), 
+[workload suites]({{ "/users-guide/workload-suite-config/" | relative_url }}), 
+and [workloads]({{ "/workloads/" | relative_url }})
+in a nested structure.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -53,6 +57,8 @@ They **can repeat a set of workloads**. Many times it is advantageous to run a w
 
 Workload suites themselves can be run serially or in parallel.
 
+Read more about [workload suites]({{ "/users-guide/workload-suite-config/" | relative_url }})
+
 ## Spark-Submit-Configs
 
 Spark-Bench allows you to launch multiple spark-submit commands by creating and launching multiple spark-submit scripts.
@@ -63,6 +69,8 @@ This can be advantageous in a number of situations. To name just a few:
 - Comparing benchmark times against two different Spark clusters!
 
 Just like workload suites and workloads, spark-submit-configs can be launched serially or in parallel.
+
+Read more about [spark-submit configs]({{ "/users-guide/spark-submit-config" | relative_url }})
 
 ## Levels and Combinations of Parallelism
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Media
+permalink: /media/
+---
+
+# Spark-Bench at Spark Summit EU 2017
+
+See Emily May Curtin's presentation about the new version of Spark-Bench! Slides are available on 
+the [conference page.](https://spark-summit.org/eu-2017/events/apache-spark-bench-simulate-test-compare-exercise-and-yes-benchmark/)
+
+<iframe width="853" height="480" src="https://www.youtube.com/embed/GGO5q_TSdgI?rel=0" frameborder="0" allowfullscreen></iframe>
+

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,17 +4,39 @@ title: Quickstart
 permalink: /quickstart/
 ---
 
-1. Grab the latest release from the [releases page on Github](https://github.com/SparkTC/spark-bench/releases/latest)
+_This guide assumes you have a working installation of Spark 2.x available and that you have access
+to the system where it is installed._
 
-2. Unzip the zip file into whatever directory you like and `cd` into the newly created folder. 
+1. Grab the `.tgz` of the latest release from the [releases page on Github](https://github.com/SparkTC/spark-bench/releases/latest).
+Although Github also packages tars and zips of the source code, you only need the file whose name begins with `spark-bench`.
+For example, `spark-bench_2.1.1_0.2.2-RELEASE_52.tgz`
+
+
+2. Unpack the file into whatever directory you like and `cd` into the newly created folder. 
+```bash
+tar -xvzf spark-bench_2.1.1_0.2.2-RELEASE_52.tgz
+cd spark-bench/
+```
 
 3. Set the environment variable for $SPARK_HOME. Example:
 ```bash
 export SPARK_HOME=/path/to/my/local/install/of/spark/
 ```
+4. Set the environment variable for your Spark master. Example:
+```bash
+export SPARK_MASTER_HOST=local[*]
+```
+or 
+```bash
+export SPARK_MASTER_HOST=yarn
+```
+or whatever is appropriate for your Standalone or Mesos environment.
+
+_NOTE: You can also modify the config files in the examples folder to set these variables,
+but this is the QUICKstart guide so we're not covering that here 🙂
+To read more about that, see our [Installation Guide](../users-guide/installation/)_
 
 4. Run the examples!
-```
-# pwd is /path/to/where/you/unzipped/spark-bench_.../
+```bash
 ./bin/spark-bench.sh examples/minimal-example.conf
 ```

--- a/readme.md
+++ b/readme.md
@@ -21,28 +21,25 @@
 [![codecov](https://codecov.io/gh/SparkTC/spark-bench/branch/master/graph/badge.svg)](https://codecov.io/gh/SparkTC/spark-bench)
 <a href="https://github.com/SparkTC/spark-bench#boards?repos=40686427"><img src="https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png"></a>
 
-# READ OUR DOCS: <https://sparktc.github.io/spark-bench/>
+# READ OUR DOCS
+The documentation for Spark-Bench is all in our shiny new docs site: <https://sparktc.github.io/spark-bench/>
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-## Table of Contents
+# Versions And Compatibility
 
-- [Current VS. Legacy Version](#current-vs-legacy-version)
-- [Current Spark version supported by spark-bench: 2.1.1](#current-spark-version-supported-by-spark-bench-211)
-- [Documentation](#documentation)
-- [Installation](#installation)
-- [Building It Yourself](#building-it-yourself)
-- [Running the Examples From The Distribution](#running-the-examples-from-the-distribution)
-  - [Creating the Distribution Folder](#creating-the-distribution-folder)
-  - [Setting Environment Variables](#setting-environment-variables)
-    - [Option 1: Setting Bash Environment Variables](#option-1-setting-bash-environment-variables)
-    - [Option 2: RECOMMENDED! Modifying Example Config Files To Include Environment Info](#option-2-recommended-modifying-example-config-files-to-include-environment-info)
-  - [Running the Examples](#running-the-examples)
-- [Previewing the Github Pages Site Locally](#previewing-the-github-pages-site-locally)
+## Spark Version
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
- 
-## Current VS. Legacy Version
+Spark-Bench is currently compiled against the Spark 2.1.1 jars and should work with Spark 2.x.
+If you experience compatibility issues between Spark-Bench and any 2.x version of Spark, please let us know!
+
+## Scala Version
+
+Spark-Bench is written using Scala 2.11.8. It is _incompatible_ with Spark versions running Scala 2.10.x
+
+# Installation
+
+Follow the [Quickstart guide](https://sparktc.github.io/spark-bench/quickstart/) from our docs site. For more details, see the [Installation page](https://sparktc.github.io/spark-bench/installation).
+
+# Legacy Version
 
 spark-bench has recently gone through an extensive rewrite.
 While we think you'll like the new capabilities, it is not quite feature complete with the previous version of spark-bench.
@@ -51,136 +48,3 @@ Many of the workloads that were available in the legacy have not yet been ported
 In the meantime, if you would like to see the old version of spark-bench, it's preserved in [the legacy branch](https://github.com/SparkTC/spark-bench/tree/legacy).
 
 You can also grab the last official release of the legacy version [from here](https://github.com/SparkTC/spark-bench/releases/tag/SparkBench_spark-v1.6).
-
-## Current Spark version supported by spark-bench: 2.1.1
-
-## Documentation
-Visit the docs website: <https://sparktc.github.io/spark-bench/>
- 
-## Installation 
-
-1. Grab the latest release from here: <https://github.com/Spark-TC/spark-bench/releases/latest>.
-2. Unpack the tarball using `tar -xvzf`.
-3. `cd` into the newly created folder.
-4. Set your environment variables
-  - Option 1: modify `SPARK_HOME` and `SPARK_MASTER_HOST` in `bin/spark-bench-env.sh` to reflect your environment. 
-  - Option 2: Recommended! Modify the config files in the examples and set `spark-home` and `spark-args = { master }` to reflect your environment. [See here for more details.](#option-2-recommended-modifying-example-config-files-to-include-environment-info)
-5. Start using spark-bench!
-
-
-## Building It Yourself
-
-Alternatively, you can also clone this repo and build it yourself. 
-
-First, install SBT according to the instructions for your system: <http://www.scala-sbt.org/0.13/docs/Setup.html>
-
-Clone this repo.
-```bash
-git clone https://github.com/Spark-TC/spark-bench.git
-cd spark-bench/
-```
-The latest changes will always be on develop, the stable version is master. Optionally check out develop here, or skip this step to stay on master.
-```bash
-git checkout develop
-```
-Building spark-bench takes more heap space than the default provided by SBT. There are several ways to set these options for SBT, 
-this is just one. I recommend adding the following line to your bash_profile:
-```bash
-export SBT_OPTS="-Xmx1536M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=2G -Xss2M"
-```
-Now you're ready to test spark-bench, if you so desire.
-```bash
-sbt test
-```
-And finally to build the distribution folder and associated tar file.
-```bash
-sbt dist
-```
-
-## Running the Examples From The Distribution
-
-The spark-bench distribution comes bundled with example scripts and configuration files that should run out out the box
-with only very limited setup.
-
-### Creating the Distribution Folder
-If you installed spark-bench by unpacking the tar file, you're ready to go. If you cloned the repo, first run
-`sbt dist` and then change into that generated folder.
-
-### Setting Environment Variables
-There are two ways to set the Spark home and master variables necessary to run the examples. 
-
-#### Option 1: Setting Bash Environment Variables
-Inside the `bin` folder is a file called `spark-bench-env.sh`. In this folder are two environment variables
-that you will be required to set. The first is `SPARK_HOME` which is simply the full path to the top level of your
-Spark installation on your laptop or cluster. The second is SPARK_MASTER_HOST which is the same as what you
-would enter as `--master` in a spark submit script for this environment. This might be `local[2]` on your laptop,
-`yarn` on a Yarn cluster, an IP address and port if you're running in standalone mode, you get the idea!
-
-You can set those environment variables in your bash profile or by uncommenting the lines in `spark-bench-env.sh`
-and filling them out in place.
-
-#### Option 2: RECOMMENDED! Modifying Example Config Files To Include Environment Info
-For example, in the minimal-example.conf, which looks like this:
-```hocon
-spark-bench = {
-  spark-submit-config = [{
-    workload-suites = [
-      {
-        descr = "One run of SparkPi and that's it!"
-        benchmark-output = "console"
-        workloads = [
-          {
-            name = "sparkpi"
-            slices = 10
-          }
-        ]
-      }
-    ]
-  }]
-}
-```
-
-Add the spark-home and master keys.
-```hocon
-spark-bench = {
-  spark-home = "/path/to/your/spark/install/" 
-  spark-submit-config = [{
-    spark-args = {
-      master = "local[*]" // or whatever the correct master is for your environment
-    }
-    workload-suites = [
-      {
-        descr = "One run of SparkPi and that's it!"
-        benchmark-output = "console"
-        workloads = [
-          {
-            name = "sparkpi"
-            slices = 10
-          }
-        ]
-      }
-    ]
-  }]
-}
-```
-
-### Running the Examples
-From the spark-bench distribution file, simply run:
-
-```bash
-./bin/spark-bench.sh ./examples/minimal-example.conf
-```
-
-The example scripts and associated configuration files are a great starting point for learning spark-bench by example.
-You can also read more about spark-bench at our [documentation site](https://sparktc.github.io/spark-bench/)
-
-
-## Previewing the Github Pages Site Locally
-
-The spark-bench documentation at <https://sparktc.github.io/spark-bench/> is generated from files in the `docs/` folder.
-To see the Jekyll site locally:
-
-1. Follow the instructions [from Github](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/)
-regarding installing Ruby, bundler, etc.
-
-2. From the `docs/` folder, run `bundle exec jekyll serve` and navigate in your browser to `127.0.0.1:4000`


### PR DESCRIPTION
This commit moves all project documentation from the README to the docs
site. This will hopefully be more user-friendly and prevent the README
documentation from getting stale.

This commit also adds a media page with the Spark-Bench presentation, a
guide for contributing to Spark-Bench, improvements to the Quickstart
guide, addition of an Installation guide, and a guide for using SBT in
the context of the project.