### PR TITLE
Benchmark output now optional

### DIFF
--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
@@ -59,7 +59,7 @@ object Configurator {
     val descr: Option[String] = Try(config.getString("descr")).toOption
     val parallel: Boolean = Try(config.getBoolean("parallel")).getOrElse(false)
     val repeat: Int = Try(config.getInt("repeat")).getOrElse(1)
-    val output: String = config.getString("benchmark-output") // throws exception
+    val output: Option[String] = Try(config.getString("benchmark-output")).toOption
     val workloads: Seq[Map[String, Seq[Any]]]  = getConfigListByName("workloads", config).map(configToMapStringAny)
 
     Suite.build(

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Suite.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Suite.scala
@@ -23,7 +23,7 @@ case class Suite(
                   description: Option[String],
                   repeat: Int = 1,
                   parallel: Boolean = false,
-                  benchmarkOutput: String,
+                  benchmarkOutput: Option[String],
                   workloadConfigs: Seq[Map[String, Any]]
 
                 )
@@ -34,7 +34,7 @@ object Suite {
             description: Option[String],
             repeat: Int,
             parallel: Boolean,
-            benchmarkOutput: String): Suite = {
+            benchmarkOutput: Option[String]): Suite = {
     Suite(
       description,
       repeat,

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
@@ -82,7 +82,7 @@ object SuiteKickoff {
     val plusSparkConf = addConfToResults(singleDF, strSparkConfs)
     val plusDescription = addConfToResults(plusSparkConf, Map("description" -> s.description)).coalesce(1)
     // And write to disk. We're done with this suite!
-    writeToDisk(s.benchmarkOutput, plusDescription, spark)
+    if(s.benchmarkOutput.nonEmpty) writeToDisk(s.benchmarkOutput.get, plusDescription, spark)
   }
 
   private def runParallel(workloadConfigs: Seq[Workload], spark: SparkSession): Seq[DataFrame] = {

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/cli/HelpersTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/cli/HelpersTest.scala
@@ -41,11 +41,11 @@ class HelpersTest extends FlatSpec with Matchers {
       Map("z" -> 20),
       Map("z" -> 30)
     )
-    val suite = Suite.build(conf, Some("description"), 1, false, "output")
+    val suite = Suite.build(conf, Some("description"), 1, false, Some("output"))
     suite.description shouldBe Some("description")
     suite.repeat shouldBe 1
     suite.parallel shouldBe false
-    suite.benchmarkOutput shouldBe "output"
+    suite.benchmarkOutput shouldBe Some("output")
     suite.workloadConfigs shouldBe res
   }
 }

--- a/docs/_users-guide/workload-suite-config.md
+++ b/docs/_users-guide/workload-suite-config.md
@@ -22,7 +22,7 @@ Workload suites can be composed with each other for benchmarking tasks or to sim
 
 | Name    | Required | Description |  
 | ---------- | ----- | --- |    
-| benchmark-output | yes | path to the file where benchmark results should be stored, or use `"console"` to print to the terminal |
+| benchmark-output | no | path to the file where benchmark results should be stored, or use `"console"` to print to the terminal |
 | descr | yes | Human-readable string description of what the suite intends to do |
 | parallel  | no | Whether the workloads in the suite run serially or in parallel. Defaults to `false`. |  
 | repeat  | no | How many times the workloads in the suite should be repeated. |  
@@ -39,6 +39,23 @@ workload-suites = [
   {
     descr = "One run of a SQL query"
     benchmark-output = "hdfs:///tmp/sql-benchmark-results.csv"
+    workloads = [
+      {
+        name = "sql"
+        input = "/tmp/generated-kmeans-data.parquet"
+        output = "/tmp/sql-query-results.parquet"
+        query = "select `0` from input where `0` < -0.9"
+      }
+    ]
+  }
+]
+```
+_Omitting `benchmark-output` will prevent benchmark results from being written._ For example, this will run the same workloads
+as above but the benchmark results will not be written, but the workload output will be written.
+```hocon
+workload-suites = [
+  {
+    descr = "One run of a SQL query with no benchmark result output"
     workloads = [
       {
         name = "sql"

--- a/examples/no-output-example.conf
+++ b/examples/no-output-example.conf
@@ -1,0 +1,15 @@
+spark-bench = {
+  spark-submit-config = [{
+    workload-suites = [
+      {
+        descr = "One run of SparkPi and that's it!"
+        workloads = [
+          {
+            name = "sparkpi"
+            slices = 10
+          }
+        ]
+      }
+    ]
+  }]
+}

--- a/version.sbt
+++ b/version.sbt
@@ -16,4 +16,4 @@
   */
 // assign version to all projects
 // Spark version 2.1.1, spark-bench version 0.2.0
-version in ThisBuild := "2.1.1_0.2.2-RELEASE"
+version in ThisBuild := "2.1.1_0.2.3-RELEASE"


### PR DESCRIPTION
When users don't specify any " benchmark-output" in their config file
there will simply be no output.