### PR TITLE
Bugfix for receiving arguments

### DIFF
--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/CLIKickoff.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/CLIKickoff.scala
@@ -17,22 +17,16 @@
 
 package com.ibm.sparktc.sparkbench.cli
 
-import java.io.File
-
-import com.ibm.sparktc.sparkbench.utils.SparkBenchException
+import org.slf4j.{Logger, LoggerFactory}
 import com.ibm.sparktc.sparkbench.workload.MultipleSuiteKickoff
 
 object CLIKickoff extends App {
-
   override def main(args: Array[String]): Unit = {
-    args.length match {
-      case 1 => {
-//        val file = new File(args.head)
-//        if(!file.exists()) throw SparkBenchException(s"Cannot find configuration file: ${file.getPath}")
-        val worksuites = Configurator(args.head)
-        MultipleSuiteKickoff.run(worksuites)
-      }
-      case _ => throw new IllegalArgumentException("Requires exactly one option: config file path")
-    }
+    val log: Logger = LoggerFactory.getLogger(this.getClass)
+    log.info(s"args received: ${args.mkString(", ")}")
+    if(args.isEmpty) throw new IllegalArgumentException("CLIKickoff received no arguments")
+    val oneStr = args.mkString(" ")
+    val worksuites = Configurator(oneStr)
+    MultipleSuiteKickoff.run(worksuites)
   }
 }

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
@@ -17,10 +17,6 @@
 
 package com.ibm.sparktc.sparkbench.cli
 
-import java.io.File
-import java.util
-
-import com.ibm.sparktc.sparkbench.utils.SparkBenchException
 import com.ibm.sparktc.sparkbench.utils.TypesafeAccessories.configToMapStringSeqAny
 
 import scala.collection.JavaConverters._
@@ -71,7 +67,4 @@ object Configurator {
       output
     )
   }
-
-
-
 }

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunch.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunch.scala
@@ -26,9 +26,7 @@ import com.ibm.sparktc.sparkbench.sparklaunch.submission.sparksubmit.SparkSubmit
 
 import scala.collection.parallel.ForkJoinTaskSupport
 import scala.collection.JavaConverters._
-import scala.sys.process._
 import scala.util.Try
-import com.ibm.sparktc.sparkbench.sparklaunch.{SparkLaunchDefaults => SLD}
 
 object SparkLaunch extends App {
 


### PR DESCRIPTION
In certain shell environments, arguments given to CLIKickoff can come as many strings instead of just one. This fix marshalls all arguments into one string and operates on a garbage-in, garbage-out principle. Because CLIKickoff is only intended to be called programmatically from Spark-Launch, this fix should suffice.