### PR TITLE
File I/O improvements

### DIFF
--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
@@ -17,6 +17,7 @@
 
 package com.ibm.sparktc.sparkbench.cli
 
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import com.ibm.sparktc.sparkbench.utils.TypesafeAccessories.configToMapStringSeqAny
 
 import scala.collection.JavaConverters._
@@ -57,6 +58,7 @@ object Configurator {
     val parallel: Boolean = Try(config.getBoolean("parallel")).getOrElse(false)
     val repeat: Int = Try(config.getInt("repeat")).getOrElse(1)
     val output: Option[String] = Try(config.getString("benchmark-output")).toOption
+    val saveMode: String = Try(config.getString("save-mode")).getOrElse(SaveModes.error)
     val workloads: Seq[Map[String, Seq[Any]]]  = getConfigListByName("workloads", config).map(configToMapStringSeqAny)
 
     Suite.build(
@@ -64,6 +66,7 @@ object Configurator {
       descr,
       repeat,
       parallel,
+      saveMode,
       output
     )
   }

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/datageneration/GraphDataGen.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/datageneration/GraphDataGen.scala
@@ -17,8 +17,8 @@
 package com.ibm.sparktc.sparkbench.datageneration
 
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import com.ibm.sparktc.sparkbench.utils.SparkBenchException
-import com.ibm.sparktc.sparkbench.utils.GeneralFunctions.{getOrDefault, getOrThrow, time, any2Long}
+import com.ibm.sparktc.sparkbench.utils.{SaveModes, SparkBenchException}
+import com.ibm.sparktc.sparkbench.utils.GeneralFunctions.{any2Long, getOrDefault, getOrThrow, time}
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 import org.apache.spark.graphx.util.GraphGenerators
@@ -42,11 +42,13 @@ object GraphDataGen extends WorkloadDefaults {
         val s = verifySuitabilityOfOutputFileFormat(str)
         Some(s)
       }
+    val saveMode = getOrDefault[String](m, "save-mode", SaveModes.error)
 
     new GraphDataGen(
       numVertices = numVertices,
       input = None,
       output = output,
+      saveMode = saveMode,
       mu = mu,
       sigma = sigma,
       seed = seed,
@@ -89,6 +91,7 @@ case class GraphDataGen (
                           numVertices: Int,
                           input: Option[String] = None,
                           output: Option[String],
+                          saveMode: String,
                           mu: Double = 4.0,
                           sigma: Double = 1.3,
                           seed: Long = 1,

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/datageneration/mlgenerator/KMeansDataGen.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/datageneration/mlgenerator/KMeansDataGen.scala
@@ -21,6 +21,7 @@ import com.ibm.sparktc.sparkbench.workload.ml.KMeansWorkload
 import com.ibm.sparktc.sparkbench.utils.SparkFuncs.writeToDisk
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import org.apache.spark.mllib.util.KMeansDataGenerator
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.{StructField, StructType}
@@ -33,6 +34,7 @@ object KMeansDataGen extends WorkloadDefaults {
     numRows = getOrThrow(m, "rows").asInstanceOf[Int],
     numCols = getOrThrow(m, "cols").asInstanceOf[Int],
     output = Some(getOrThrow(m, "output").asInstanceOf[String]),
+    saveMode = getOrDefault[String](m, "save-mode", SaveModes.error),
     k = getOrDefault[Int](m, "k", KMeansWorkload.numOfClusters),
     scaling = getOrDefault[Double](m, "scaling", KMeansWorkload.scaling),
     numPartitions = getOrDefault[Int](m, "partitions", KMeansWorkload.numOfPartitions)
@@ -44,6 +46,7 @@ case class KMeansDataGen(
                           numCols: Int,
                           input: Option[String] = None,
                           output: Option[String],
+                          saveMode: String,
                           k: Int,
                           scaling: Double,
                           numPartitions: Int
@@ -71,7 +74,7 @@ case class KMeansDataGen(
       spark.createDataFrame(rowRDD, schema)
     }
 
-    val (saveTime, _) = time { writeToDisk(output.get, dataDF, spark) }
+    val (saveTime, _) = time { writeToDisk(output.get, saveMode, dataDF, spark) }
 
     val timeResultSchema = StructType(
       List(

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/datageneration/mlgenerator/LinearRegressionDataGen.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/datageneration/mlgenerator/LinearRegressionDataGen.scala
@@ -21,7 +21,7 @@ import org.apache.spark.mllib.util.LinearDataGenerator
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import com.ibm.sparktc.sparkbench.utils.SparkBenchException
+import com.ibm.sparktc.sparkbench.utils.{SaveModes, SparkBenchException}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions.{getOrDefault, getOrThrow, time}
 import com.ibm.sparktc.sparkbench.utils.SparkFuncs.writeToDisk
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
@@ -40,6 +40,7 @@ object LinearRegressionDataGen extends WorkloadDefaults {
     numRows = getOrThrow(m, "rows").asInstanceOf[Int],
     numCols = getOrThrow(m, "cols").asInstanceOf[Int],
     output = Some(getOrThrow(m, "output").asInstanceOf[String]),
+    saveMode = getOrDefault[String](m, "save-mode", SaveModes.error),
     eps = getOrDefault[Double](m, "eps", eps),
     intercepts = getOrDefault[Double](m, "intercepts", intercepts),
     numPartitions = getOrDefault[Int](m, "partitions", numOfPartitions)
@@ -51,6 +52,7 @@ case class LinearRegressionDataGen (
                                       numCols: Int,
                                       input: Option[String] = None,
                                       output: Option[String],
+                                      saveMode: String,
                                       eps: Double,
                                       intercepts: Double,
                                       numPartitions: Int
@@ -79,7 +81,7 @@ case class LinearRegressionDataGen (
     val (saveTime, _) = time {
       val outputstr = output.get
       if(outputstr.endsWith(".csv")) throw SparkBenchException("LabeledPoints cannot be saved to CSV. Please try outputting to Parquet instead.")
-      writeToDisk(output.get, dataDF, spark)
+      writeToDisk(output.get, saveMode, dataDF, spark)
     }//TODO you can't output this to CSV. Parquet is fine
 
     val timeResultSchema = StructType(

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Suite.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Suite.scala
@@ -24,6 +24,7 @@ case class Suite(
                   repeat: Int = 1,
                   parallel: Boolean = false,
                   benchmarkOutput: Option[String],
+                  saveMode: String,
                   workloadConfigs: Seq[Map[String, Any]]
                 )
 
@@ -32,12 +33,14 @@ object Suite {
             description: Option[String],
             repeat: Int,
             parallel: Boolean,
+            saveMode: String,
             benchmarkOutput: Option[String]): Suite = {
     Suite(
       description,
       repeat,
       parallel,
       benchmarkOutput,
+      saveMode,
       confsFromArgs.flatMap( splitGroupedConfigToIndividualConfigs )
     )
   }

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
@@ -58,7 +58,7 @@ import scala.collection.parallel.ForkJoinTaskSupport
 object SuiteKickoff {
 
   def run(s: Suite, spark: SparkSession): Unit = {
-    verifyCanWriteOrThrow(s.benchmarkOutput, s.saveMode, spark)
+    verifyOutput(s.benchmarkOutput, s.saveMode, spark)
 
     // Translate the maps into runnable workloads
     val workloads: Seq[Workload] = s.workloadConfigs.map(ConfigCreator.mapToConf)

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
@@ -17,7 +17,7 @@
 
 package com.ibm.sparktc.sparkbench.workload
 
-import com.ibm.sparktc.sparkbench.utils.SparkFuncs.{writeToDisk, addConfToResults}
+import com.ibm.sparktc.sparkbench.utils.SparkFuncs._
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.functions.{col, lit}
 
@@ -58,6 +58,8 @@ import scala.collection.parallel.ForkJoinTaskSupport
 object SuiteKickoff {
 
   def run(s: Suite, spark: SparkSession): Unit = {
+    verifyCanWriteOrThrow(s.benchmarkOutput, s.saveMode, spark)
+
     // Translate the maps into runnable workloads
     val workloads: Seq[Workload] = s.workloadConfigs.map(ConfigCreator.mapToConf)
 
@@ -82,7 +84,7 @@ object SuiteKickoff {
     val plusSparkConf = addConfToResults(singleDF, strSparkConfs)
     val plusDescription = addConfToResults(plusSparkConf, Map("description" -> s.description)).coalesce(1)
     // And write to disk. We're done with this suite!
-    if(s.benchmarkOutput.nonEmpty) writeToDisk(s.benchmarkOutput.get, plusDescription, spark)
+    if(s.benchmarkOutput.nonEmpty) writeToDisk(s.benchmarkOutput.get, s.saveMode, plusDescription, spark)
   }
 
   private def runParallel(workloadConfigs: Seq[Workload], spark: SparkSession): Seq[DataFrame] = {

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
@@ -18,7 +18,7 @@
 package com.ibm.sparktc.sparkbench.workload
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import com.ibm.sparktc.sparkbench.utils.SparkFuncs.{load, addConfToResults}
+import com.ibm.sparktc.sparkbench.utils.SparkFuncs._
 
 trait WorkloadDefaults {
   val name: String
@@ -28,6 +28,7 @@ trait WorkloadDefaults {
 trait Workload {
   val input: Option[String]
   val output: Option[String]
+  val saveMode: String
 
   /**
     *  Validate that the data set has a correct schema and fix if necessary.
@@ -43,6 +44,8 @@ trait Workload {
   def doWorkload(df: Option[DataFrame], sparkSession: SparkSession): DataFrame
 
   def run(spark: SparkSession): DataFrame = {
+
+    verifyCanWriteOrThrow(output, saveMode, spark)
 
     val df = input match {
       case None => None

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
@@ -17,6 +17,7 @@
 
 package com.ibm.sparktc.sparkbench.workload
 
+import com.ibm.sparktc.sparkbench.utils.{SaveModes, SparkBenchException}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import com.ibm.sparktc.sparkbench.utils.SparkFuncs._
 
@@ -46,6 +47,10 @@ trait Workload {
   def run(spark: SparkSession): DataFrame = {
 
     verifyCanWriteOrThrow(output, saveMode, spark)
+    if(saveMode == SaveModes.append){
+      throw SparkBenchException("Save-mode \"append\" not available for workload results. " +
+        "Please use \"errorifexists\", \"ignore\", or \"overwrite\" instead.")
+    }
 
     val df = input match {
       case None => None

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
@@ -46,7 +46,7 @@ trait Workload {
 
   def run(spark: SparkSession): DataFrame = {
 
-    verifyCanWriteOrThrow(output, saveMode, spark)
+    verifyOutput(output, saveMode, spark)
     if(saveMode == SaveModes.append){
       throw SparkBenchException("Save-mode \"append\" not available for workload results. " +
         "Please use \"errorifexists\", \"ignore\", or \"overwrite\" instead.")

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/CacheTest.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/CacheTest.scala
@@ -19,6 +19,7 @@ package com.ibm.sparktc.sparkbench.workload.exercise
 
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 case class CacheTestResult(name: String, timestamp: Long, runTime1: Long, runTime2: Long, runTime3: Long)
@@ -32,8 +33,9 @@ object CacheTest extends WorkloadDefaults {
 }
 
 case class CacheTest(input: Option[String],
-                    output: Option[String],
-                    sleepMs: Long) extends Workload {
+                     output: Option[String],
+                     saveMode: String = SaveModes.error,
+                     sleepMs: Long) extends Workload {
 
   def doWorkload(df: Option[DataFrame], spark: SparkSession): DataFrame = {
     import spark.implicits._

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/PartitionAndSleepWorkload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/PartitionAndSleepWorkload.scala
@@ -20,6 +20,7 @@ package com.ibm.sparktc.sparkbench.workload.exercise
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 
@@ -37,6 +38,7 @@ object PartitionAndSleepWorkload extends WorkloadDefaults {
 
 case class PartitionAndSleepWorkload(input: Option[String] = None,
                                      output: Option[String] = None,
+                                     saveMode: String = SaveModes.error,
                                      partitions: Int,
                                      sleepMS: Long) extends Workload {
 

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/Sleep.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/Sleep.scala
@@ -21,7 +21,7 @@ import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import breeze.stats.distributions.{Poisson, Rand}
-import com.ibm.sparktc.sparkbench.utils.SparkBenchException
+import com.ibm.sparktc.sparkbench.utils.{SaveModes, SparkBenchException}
 
 case class SleepResult(
                         name: String,
@@ -138,6 +138,7 @@ object Sleep extends WorkloadDefaults {
 case class Sleep(
                 input: Option[String] = None,
                 output: Option[String] = None,
+                saveMode: String = SaveModes.error,
                 sleepMS: Long,
                 distribution: Option[String] = None,
                 distributionMean: Option[Double] = None,

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPi.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPi.scala
@@ -34,7 +34,7 @@ case class SparkPiResult(
 
 object SparkPi extends WorkloadDefaults {
   val name = "sparkpi"
-  def apply(m: Map[String, Any])  =
+  def apply(m: Map[String, Any]) =
     new SparkPi(input = m.get("input").map(_.asInstanceOf[String]),
       output = None,
       slices = getOrDefault[Int](m, "slices", 2)

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPi.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPi.scala
@@ -18,6 +18,7 @@
 package com.ibm.sparktc.sparkbench.workload.exercise
 
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions.{getOrDefault, time}
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -33,7 +34,7 @@ case class SparkPiResult(
 
 object SparkPi extends WorkloadDefaults {
   val name = "sparkpi"
-  def apply(m: Map[String, Any]) =
+  def apply(m: Map[String, Any])  =
     new SparkPi(input = m.get("input").map(_.asInstanceOf[String]),
       output = None,
       slices = getOrDefault[Int](m, "slices", 2)
@@ -42,6 +43,7 @@ object SparkPi extends WorkloadDefaults {
 
 case class SparkPi(input: Option[String] = None,
                     output: Option[String] = None,
+                    saveMode: String = SaveModes.error,
                     slices: Int
                   ) extends Workload {
 

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/ml/KMeansWorkload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/ml/KMeansWorkload.scala
@@ -26,6 +26,7 @@ import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 
 /*
  * (C) Copyright IBM Corp. 2015 
@@ -58,6 +59,7 @@ object KMeansWorkload extends WorkloadDefaults {
   def apply(m: Map[String, Any]) = new KMeansWorkload(
     input = Some(getOrThrow(m, "input").asInstanceOf[String]),
     output = getOrDefault[Option[String]](m, "workloadresultsoutputdir", None),
+    saveMode = getOrDefault[String](m, "save-mode", SaveModes.error),
     k = getOrDefault[Int](m, "k", numOfClusters),
     seed = getOrDefault(m, "seed", seed, any2Long),
     maxIterations = getOrDefault[Int](m, "maxiterations", maxIteration))
@@ -66,6 +68,7 @@ object KMeansWorkload extends WorkloadDefaults {
 
 case class KMeansWorkload(input: Option[String],
                           output: Option[String],
+                          saveMode: String,
                           k: Int,
                           seed: Long,
                           maxIterations: Int) extends Workload {
@@ -141,7 +144,7 @@ case class KMeansWorkload(input: Option[String],
       }
       import spark.implicits._
       // Already performed the match one level up so these are guaranteed to be Some(something)
-      writeToDisk(output.get, vectorsAndClusterIdx.toDF(), spark = spark)
+      writeToDisk(output.get, saveMode, vectorsAndClusterIdx.toDF(), spark = spark)
     }
     ds.unpersist()
     res

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/ml/LogisticRegressionWorkload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/ml/LogisticRegressionWorkload.scala
@@ -18,6 +18,7 @@
 package com.ibm.sparktc.sparkbench.workload.ml
 
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.classification.LogisticRegression
@@ -50,6 +51,7 @@ object LogisticRegressionWorkload extends WorkloadDefaults {
   def apply(m: Map[String, Any]) = new LogisticRegressionWorkload(
     input = Some(getOrThrow(m, "input").asInstanceOf[String]),
     output = getOrDefault[Option[String]](m, "workloadresultsoutputdir", None),
+    saveMode = getOrDefault[String](m, "save-mode", SaveModes.error),
     testFile = getOrThrow(m, "testfile").asInstanceOf[String],
     numPartitions = getOrDefault[Int](m, "numpartitions", 32),
     cacheEnabled = getOrDefault[Boolean](m, "cacheenabled", true)
@@ -60,6 +62,7 @@ object LogisticRegressionWorkload extends WorkloadDefaults {
 case class LogisticRegressionWorkload(
                                        input: Option[String],
                                        output: Option[String],
+                                       saveMode: String,
                                        testFile: String,
                                        numPartitions: Int,
                                        cacheEnabled: Boolean

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/sql/SQLWorkload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/sql/SQLWorkload.scala
@@ -18,6 +18,7 @@
 package com.ibm.sparktc.sparkbench.workload.sql
 
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import com.ibm.sparktc.sparkbench.utils.SparkFuncs._
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -36,6 +37,7 @@ object SQLWorkload extends WorkloadDefaults {
   def apply(m: Map[String, Any]) =
     new SQLWorkload(input = m.get("input").map(_.asInstanceOf[String]),
       output = m.get("output").map(_.asInstanceOf[String]),
+      saveMode = getOrDefault[String](m, "save-mode", SaveModes.error),
       queryStr = getOrThrow(m, "query").asInstanceOf[String],
       cache = getOrDefault[Boolean](m, "cache", false)
     )
@@ -44,6 +46,7 @@ object SQLWorkload extends WorkloadDefaults {
 
 case class SQLWorkload (input: Option[String],
                         output: Option[String] = None,
+                        saveMode: String,
                         queryStr: String,
                         cache: Boolean) extends Workload {
 
@@ -59,7 +62,7 @@ case class SQLWorkload (input: Option[String],
   }
 
   def save(res: DataFrame, where: String, spark: SparkSession): (Long, Unit) = time {
-    writeToDisk(where, res, spark)
+    writeToDisk(where, saveMode, res, spark)
   }
 
   override def doWorkload(df: Option[DataFrame] = None, spark: SparkSession): DataFrame = {

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/cli/HelpersTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/cli/HelpersTest.scala
@@ -41,7 +41,7 @@ class HelpersTest extends FlatSpec with Matchers {
       Map("z" -> 20),
       Map("z" -> 30)
     )
-    val suite = Suite.build(conf, Some("description"), 1, false, Some("output"))
+    val suite = Suite.build(conf, Some("description"), 1, false, "error", Some("output"))
     suite.description shouldBe Some("description")
     suite.repeat shouldBe 1
     suite.parallel shouldBe false

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/cli/HelpersTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/cli/HelpersTest.scala
@@ -17,6 +17,7 @@
 
 package com.ibm.sparktc.sparkbench.cli
 
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import com.ibm.sparktc.sparkbench.workload.Suite
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -41,7 +42,7 @@ class HelpersTest extends FlatSpec with Matchers {
       Map("z" -> 20),
       Map("z" -> 30)
     )
-    val suite = Suite.build(conf, Some("description"), 1, false, "error", Some("output"))
+    val suite = Suite.build(conf, Some("description"), 1, false, SaveModes.error, Some("output"))
     suite.description shouldBe Some("description")
     suite.repeat shouldBe 1
     suite.parallel shouldBe false

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/testfixtures/BuildAndTeardownData.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/testfixtures/BuildAndTeardownData.scala
@@ -20,6 +20,7 @@ package com.ibm.sparktc.sparkbench.testfixtures
 import java.io.File
 
 import com.holdenkarau.spark.testing.Utils
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import com.ibm.sparktc.sparkbench.utils.SparkFuncs.writeToDisk
 import com.ibm.sparktc.sparkbench.workload.ml.KMeansWorkload
 import org.apache.spark.mllib.util.KMeansDataGenerator
@@ -62,6 +63,6 @@ class BuildAndTeardownData(dirname: String = System.currentTimeMillis.toString) 
 
     val df = spark.createDataFrame(rowRDD, schema)
 
-    writeToDisk(outputFile, df, spark)
+    writeToDisk(outputFile, SaveModes.overwrite, df, spark)
   }
 }

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/ml/KMeansWorkloadTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/ml/KMeansWorkloadTest.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import com.holdenkarau.spark.testing.Utils
 import com.ibm.sparktc.sparkbench.testfixtures.SparkSessionProvider
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import com.ibm.sparktc.sparkbench.workload.ml.KMeansWorkload
 import com.ibm.sparktc.sparkbench.utils.SparkFuncs.{load, writeToDisk}
 import org.apache.spark.mllib.util.KMeansDataGenerator
@@ -50,7 +51,7 @@ class KMeansWorkloadTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
   "reconcileSchema" should "handle a StringType schema and turn it into a DoubleType Schema" in {
     val df2Disk = makeDataFrame()
-    writeToDisk(fileName, df2Disk, spark, Some("csv"))
+    writeToDisk(fileName, SaveModes.error, df2Disk, spark, Some("csv"))
     val conf = Map("name" -> "kmeans", "input" -> fileName)
     val work = KMeansWorkload(conf)
     val df = load(spark, fileName)
@@ -69,7 +70,7 @@ class KMeansWorkloadTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
   it should "work even when we've pulled the data from disk" in {
     val df2Disk = makeDataFrame()
-    writeToDisk(fileName, df2Disk, spark, Some("csv"))
+    writeToDisk(fileName, SaveModes.error, df2Disk, spark, Some("csv"))
     val conf = Map("name" -> "kmeans", "input" -> fileName)
     val work = KMeansWorkload(conf)
     val df = load(spark, fileName)
@@ -80,7 +81,7 @@ class KMeansWorkloadTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
   "doWorkload" should "work" in {
     val df2Disk = makeDataFrame()
-    writeToDisk(fileName, df2Disk, spark, Some("csv"))
+    writeToDisk(fileName, SaveModes.error, df2Disk, spark, Some("csv"))
     val conf = Map("name" -> "kmeans", "input" -> fileName)
     val work = KMeansWorkload(conf)
     val df = load(spark, fileName)

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/sql/SQLWorkloadTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/sql/SQLWorkloadTest.scala
@@ -19,6 +19,7 @@ package com.ibm.sparktc.sparkbench.workload.sql
 
 import com.ibm.sparktc.sparkbench.testfixtures.SparkSessionProvider
 import com.ibm.sparktc.sparkbench.testfixtures.BuildAndTeardownData
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 class SQLWorkloadTest extends FlatSpec with Matchers with BeforeAndAfterAll {
@@ -44,6 +45,7 @@ class SQLWorkloadTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     val workload = SQLWorkload(input = Some(smallData),
       output = Some(resOutput),
+      saveMode = SaveModes.error,
       queryStr = "select `0` from input where `0` < -0.9",
       cache = false)
 

--- a/docs/_users-guide/workload-suite-config.md
+++ b/docs/_users-guide/workload-suite-config.md
@@ -20,12 +20,13 @@ Workload suites can be composed with each other for benchmarking tasks or to sim
 
 ## Parameters
 
-| Name    | Required | Description |  
-| ---------- | ----- | --- |    
-| benchmark-output | no | path to the file where benchmark results should be stored, or use `"console"` to print to the terminal |
-| descr | yes | Human-readable string description of what the suite intends to do |
-| parallel  | no | Whether the workloads in the suite run serially or in parallel. Defaults to `false`. |  
-| repeat  | no | How many times the workloads in the suite should be repeated. |  
+| Name             | Required | Default | Description |  
+| ---------------- | -------- | ------- | ----------- |    
+| benchmark-output | no       | -       | path to the file where benchmark results should be stored, or use `"console"` to print to the terminal |
+| save-mode        | no       | errorifexists | Options are "errorifexists", "ignore" (no-op if exists), "overwrite", and "append" |
+| descr            | yes      | -       | Human-readable string description of what the suite intends to do |
+| parallel         | no       | false   | Whether the workloads in the suite run serially or in parallel. Defaults to `false`. |  
+| repeat           | no       | 1       | How many times the workloads in the suite should be repeated. |  
 
 ## benchmark-output
 
@@ -67,6 +68,18 @@ workload-suites = [
   }
 ]
 ```
+
+## save-mode
+
+If users specify benchmark-output they can use this option to specify write behavior.
+Options are
+  - errorifexists: if the file exists, throw an error
+  - ignore: if the file exists, no-op
+  - overwrite: if the file exists, overwrite it
+  - append: if the file exists, append to it
+
+Note: "append" is allowed for benchmark-output as it may be conceptually the same dataset,
+but disallowed for workload output as those are conceptually different datasets.
 
 ## descr
 

--- a/docs/_workloads/data-generator-graph.md
+++ b/docs/_workloads/data-generator-graph.md
@@ -30,6 +30,7 @@ All other output file formats will cause an error.
 | ------- |---------------| ---------| ----------- |  
 | name       | yes | -- | "graph-data-generator" |  
 | output   | yes | -- | output file. MUST BE .TXT FORMAT |
+| save-mode | no | errorifexists | Options are "errorifexists", "ignore" (no-op if exists), and "overwrite" |
 | vertices      | yes | -- | Number of vertices in the graph |  
 | mu | no | 4.0 | mean of out-degree distribution |  
 | sigma | no| 1.3 | standard deviation of out-degree distribution |  

--- a/docs/_workloads/data-generator-kmeans.md
+++ b/docs/_workloads/data-generator-kmeans.md
@@ -11,6 +11,7 @@ title: Data Generator - KMeans
 | rows      | yes | -- | number of rows to generate |
 | cols     | yes | -- | number of columns to generate |
 | output   | yes | -- | output file |
+| save-mode | no | errorifexists | Options are "errorifexists", "ignore" (no-op if exists), and "overwrite" |
 | k      | no | 2 | number of clusters generated |
 | scaling | no | 0.6 | scaling factor of the the dataset|
 | partitions | no| 2 | number of partitions|

--- a/docs/_workloads/data-generator-linear-regression.md
+++ b/docs/_workloads/data-generator-linear-regression.md
@@ -10,6 +10,7 @@ title: Data Generator - Linear Regression
 | rows      | yes | -- | number of rows to generate |
 | cols     | yes | -- | number of columns to generate |
 | output   | yes | -- | output file |
+| save-mode | no | errorifexists | Options are "errorifexists", "ignore" (no-op if exists), and "overwrite" |
 | eps      | no | 2 | epsilon factor by which examples are scaled |
 | intercepts | no | 0.1 | data intercept |
 | partitions | no| 10 | number of partitions|

--- a/docs/_workloads/kmeans.md
+++ b/docs/_workloads/kmeans.md
@@ -21,6 +21,7 @@ will be passed upwards and outputted with the workload suite.
 | name       | yes | -- | "kmeans" |
 | input | yes | -- | the input dataset |
 | output | no | -- | If users wish to capture the actual results of the kmeans algorithm, they can specify an output file here. |
+| save-mode | no | errorifexists | Options are "errorifexists", "ignore" (no-op if exists), and "overwrite" |
 | k     | no | 2 | number of clusters |
 | seed  | no | 127L | initial values |
 | maxiterations  | no | 2 | maximum number of times the algorithm should iterate |  

--- a/docs/_workloads/logistic-regression.md
+++ b/docs/_workloads/logistic-regression.md
@@ -15,6 +15,7 @@ Runs LogisticRegression over the input datasets.
 | input          | yes | --    | path to the training dataset |
 | testfile       | yes | --    | path to the test dataset |
 | output         | no  | --    | If users wish to capture the actual results of the workload, they can specify an output file here. |
+| save-mode | no | errorifexists | Options are "errorifexists", "ignore" (no-op if exists), and "overwrite" |
 | numpartitions  | no  | 32    | number of partitions |
 | cacheenabled   | no  | false | whether or not the datasets are cached after being read from disk |
 

--- a/docs/_workloads/sql.md
+++ b/docs/_workloads/sql.md
@@ -23,6 +23,7 @@ select `0` from input where `0` < -0.9
 | name        | yes      | -- | "sql" |
 | input       | yes      | -- | the input dataset |
 | output      | no       | -- | If users wish to capture the actual results of the SQL query, they can specify an output file here. |
+| save-mode | no | errorifexists | Options are "errorifexists", "ignore" (no-op if exists), and "overwrite" |
 | query    | yes      | --    | the sql query to perform. The table name must be "input" as shown in the examples above. |
 | cache       | no       | false | whether the dataset should be cached after being read from disk |
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,8 @@ object Dependencies {
   val sparkDeps = Seq(
     "org.apache.spark" %% "spark-core"  % sparkVersion % "provided",
     "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided",
-    "org.apache.spark" %% "spark-sql"   % sparkVersion % "provided"
+    "org.apache.spark" %% "spark-sql"   % sparkVersion % "provided",
+    "com.databricks"   %% "spark-avro"  % "4.0.0"
   )
 
   val breezeDeps = Seq(

--- a/test-workloads/src/main/scala/com/ibm/sparktc/sparkbench/workload/custom/HelloWorld.scala
+++ b/test-workloads/src/main/scala/com/ibm/sparktc/sparkbench/workload/custom/HelloWorld.scala
@@ -19,6 +19,7 @@ package com.ibm.sparktc.sparkbench.workload.custom
 
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
+import com.ibm.sparktc.sparkbench.utils.SaveModes
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 // Create a quick case class with a member for each field we want to return in the results.
@@ -63,6 +64,7 @@ object HelloString extends WorkloadDefaults {
 case class HelloString(
                         input: Option[String] = None,
                         output: Option[String] = None,
+                        saveMode: String = SaveModes.error,
                         str: String
                       ) extends Workload {
 

--- a/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/FileConstants.scala
+++ b/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/FileConstants.scala
@@ -1,0 +1,34 @@
+/**
+  * (C) Copyright IBM Corp. 2015 - 2018
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  */
+
+package com.ibm.sparktc.sparkbench.utils
+
+object SaveModes {
+  val overwrite = "overwrite"
+  val ignore = "ignore"
+  val append = "append"
+  val error = "error"
+}
+
+object Formats {
+  val parquet = "parquet"
+  val csv = "csv"
+  val orc = "orc"
+  val avro = "avro"
+  val json = "json"
+  val console = "console"
+}

--- a/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
+++ b/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
@@ -38,6 +38,7 @@ object SparkFuncs {
         case (true, SaveModes.append) => true
         case (true, SaveModes.error) => false
         case (true, SaveModes.ignore) => true // allow write operation to no-op when the time comes
+        case (true, _) => throw SparkBenchException(s"Unrecognized or unimplemented save-mode: $saveMode")
       }
     }
   }

--- a/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
+++ b/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
@@ -19,6 +19,7 @@ package com.ibm.sparktc.sparkbench.utils
 
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import com.databricks.spark.avro._
 
 object SparkFuncs {
 
@@ -35,6 +36,9 @@ object SparkFuncs {
     format match {
       case "parquet" => data.write.parquet(outputDir)
       case "csv" => data.write.option("header", "true").csv(outputDir)
+      case "orc" => data.write.orc(outputDir)
+      case "avro" => data.write.avro(outputDir)
+      case "json" => data.write.json(outputDir)
       case "console" => data.show()
       case _ => throw new Exception(s"Unrecognized or unspecified save format. " +
         s"Please check the file extension or add a file format to your arguments: $outputDir")
@@ -52,6 +56,9 @@ object SparkFuncs {
 
     inputFormat match {
       case "parquet" => spark.read.parquet(inputDir)
+      case "orc" => spark.read.orc(inputDir)
+      case "avro" => spark.read.avro(inputDir)
+      case "json" => spark.read.json(inputDir)
       case "csv" | _ => spark.read.option("inferSchema", "true").option("header", "true").csv(inputDir) //if unspecified, assume csv
     }
   }


### PR DESCRIPTION
Three commits that represent improvements to file I/O in Spark-Bench.
- Adds functionality for Avro, JSON, and ORC
- Adds the ability to specify "save-mode" with values "errorifexists", "overwrite", "ignore", and for benchmark results "append".
