### PR TITLE
modify tutorial page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -166,7 +166,7 @@ spark-bench = {
             cols = 14
           },
           {
-            name = "data-generation-logistic-regression"
+            name = "data-generation-lr"
             output = "/tmp/spark-bench-test/logistic-regression.parquet"
             rows = 1000000
             cols = 14
@@ -185,7 +185,7 @@ spark-bench = {
             // not specifying any kmeans arguments as we want the defaults for benchmarking
           },
           {
-            name = "logisticregression"
+            name = "lr-bml"
             input = "/tmp/spark-bench-test/logistic-regression.parquet"
             // again, not specifying arguments
           },


### PR DESCRIPTION
In an example of a config for classic benchmarking,
the values of name field regarding Logistic Regression were wrong.
Changed like this.
* data-generation-logistic-regression -> data-generation-lr
* logisticregression -> lr-bml