### PR TITLE
Fix spark-home docs

### DIFF
--- a/docs/_users-guide/installation.md
+++ b/docs/_users-guide/installation.md
@@ -69,8 +69,8 @@ spark-bench = {
 Add the spark-home and master keys.
 ```hocon
 spark-bench = {
-  spark-home = "/path/to/your/spark/install/" 
   spark-submit-config = [{
+    spark-home = "/path/to/your/spark/install/" 
     spark-args = {
       master = "local[*]" // or whatever the correct master is for your environment
     }


### PR DESCRIPTION
Is seems to be an error in your docs in the `spark-home` location.

This could be very hard to find for new users, could this be merged ? 